### PR TITLE
remove register specifier from cpython source files

### DIFF
--- a/Include/stringobject.h
+++ b/Include/stringobject.h
@@ -170,9 +170,9 @@ PyAPI_FUNC(PyObject*) PyString_AsDecodedString(
    cause an exception).  */
 
 PyAPI_FUNC(int) PyString_AsStringAndSize(
-    register PyObject *obj,	/* string or Unicode object */
-    register char **s,		/* pointer to buffer variable */
-    register Py_ssize_t *len	/* pointer to length variable or NULL
+    PyObject *obj,	/* string or Unicode object */
+    char **s,		/* pointer to buffer variable */
+    Py_ssize_t *len	/* pointer to length variable or NULL
 				   (only possible for 0-terminated
 				   strings) */
     );

--- a/Include/unicodeobject.h
+++ b/Include/unicodeobject.h
@@ -531,7 +531,7 @@ PyAPI_FUNC(int) PyUnicode_Resize(
 */
 
 PyAPI_FUNC(PyObject*) PyUnicode_FromEncodedObject(
-    register PyObject *obj,     /* Object */
+    PyObject *obj,     /* Object */
     const char *encoding,       /* encoding */
     const char *errors          /* error handling */
     );
@@ -550,7 +550,7 @@ PyAPI_FUNC(PyObject*) PyUnicode_FromEncodedObject(
 */
 
 PyAPI_FUNC(PyObject*) PyUnicode_FromObject(
-    register PyObject *obj      /* Object */
+    PyObject *obj      /* Object */
     );
 
 PyAPI_FUNC(PyObject *) PyUnicode_FromFormatV(const char*, va_list);
@@ -572,7 +572,7 @@ PyAPI_FUNC(PyObject *) _PyUnicode_FormatAdvanced(PyObject *obj,
    The buffer is copied into the new object. */
 
 PyAPI_FUNC(PyObject*) PyUnicode_FromWideChar(
-    register const wchar_t *w,  /* wchar_t buffer */
+    const wchar_t *w,  /* wchar_t buffer */
     Py_ssize_t size             /* size of buffer */
     );
 
@@ -590,7 +590,7 @@ PyAPI_FUNC(PyObject*) PyUnicode_FromWideChar(
 
 PyAPI_FUNC(Py_ssize_t) PyUnicode_AsWideChar(
     PyUnicodeObject *unicode,   /* Unicode object */
-    register wchar_t *w,        /* wchar_t buffer */
+    wchar_t *w,        /* wchar_t buffer */
     Py_ssize_t size             /* size of buffer */
     );
 

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -5772,8 +5772,8 @@ PyObject *My_PyUnicode_FromWideChar(register const wchar_t *w,
     memcpy(unicode->str, w, size * sizeof(wchar_t));
 #else
     {
-        register Py_UNICODE *u;
-        register int i;
+        Py_UNICODE *u;
+        int i;
         u = PyUnicode_AS_UNICODE(unicode);
         /* In Python, the following line has a one-off error */
         for (i = size; i > 0; i--)
@@ -5785,7 +5785,7 @@ PyObject *My_PyUnicode_FromWideChar(register const wchar_t *w,
 }
 
 Py_ssize_t My_PyUnicode_AsWideChar(PyUnicodeObject *unicode,
-                            register wchar_t *w,
+                            wchar_t *w,
                             Py_ssize_t size)
 {
     if (unicode == NULL) {
@@ -5798,8 +5798,8 @@ Py_ssize_t My_PyUnicode_AsWideChar(PyUnicodeObject *unicode,
     memcpy(w, unicode->str, size * sizeof(wchar_t));
 #else
     {
-        register Py_UNICODE *u;
-        register int i;
+        Py_UNICODE *u;
+        int i;
         u = PyUnicode_AS_UNICODE(unicode);
         /* In Python, the following line has a one-off error */
         for (i = size; i > 0; i--)

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -5753,7 +5753,7 @@ init_ctypes(void)
 #if (PY_VERSION_HEX < 0x02040000)
 #ifdef HAVE_WCHAR_H
 
-PyObject *My_PyUnicode_FromWideChar(register const wchar_t *w,
+PyObject *My_PyUnicode_FromWideChar(const wchar_t *w,
                                     Py_ssize_t size)
 {
     PyUnicodeObject *unicode;

--- a/Modules/_ctypes/libffi/src/alpha/ffi.c
+++ b/Modules/_ctypes/libffi/src/alpha/ffi.c
@@ -49,7 +49,7 @@ ffi_status
 ffi_prep_cif_machdep(ffi_cif *cif)
 {
   /* Adjust cif->bytes to represent a minimum 6 words for the temporary
-     register argument loading area.  */
+     argument loading area.  */
   if (cif->bytes < 6*FFI_SIZEOF_ARG)
     cif->bytes = 6*FFI_SIZEOF_ARG;
 

--- a/Modules/_ctypes/libffi/src/avr32/ffi.c
+++ b/Modules/_ctypes/libffi/src/avr32/ffi.c
@@ -269,12 +269,12 @@ void ffi_call(ffi_cif *cif, void (*fn)(void), void *rvalue, void **avalue)
 static void ffi_prep_incoming_args_SYSV(char *stack, void **rvalue,
     void **avalue, ffi_cif *cif)
 {
-    register unsigned int i, reg_mask = 0;
-    register void **p_argv;
-    register ffi_type **p_arg;
-    register char *reg_base = stack;
-    register char *stack_base = stack + 20;
-    register unsigned int stack_offset = 0;
+    unsigned int i, reg_mask = 0;
+    void **p_argv;
+    ffi_type **p_arg;
+    char *reg_base = stack;
+    char *stack_base = stack + 20;
+    unsigned int stack_offset = 0;
 
 #ifdef DEBUG
     /* Debugging */

--- a/Modules/_ctypes/libffi/src/frv/ffi.c
+++ b/Modules/_ctypes/libffi/src/frv/ffi.c
@@ -228,7 +228,7 @@ void ffi_closure_eabi (unsigned arg1, unsigned arg2, unsigned arg3,
       /* The caller allocates space for the return structure, and
        passes a pointer to this space in gr3.  Use this value directly
        as the return value.  */
-      register void *return_struct_ptr __asm__("gr3");
+      void *return_struct_ptr __asm__("gr3");
       (closure->fun) (cif, return_struct_ptr, avalue, closure->user_data);
     }
   else

--- a/Modules/_ctypes/libffi/src/s390/ffi.c
+++ b/Modules/_ctypes/libffi/src/s390/ffi.c
@@ -452,7 +452,7 @@ ffi_prep_cif_machdep(ffi_cif *cif)
 
 	  /* On 31-bit machines, 64-bit integers are passed in GPR pairs,
 	     if one is still available, or else on the stack.  If only one
-	     register is free, skip the register (it won't be used for any 
+	     is free, skip the register (it won't be used for any 
 	     subsequent argument either).  */
 	      
 #ifndef __s390x__

--- a/Modules/_ctypes/libffi_osx/x86/x86-ffi_darwin.c
+++ b/Modules/_ctypes/libffi_osx/x86/x86-ffi_darwin.c
@@ -39,10 +39,10 @@ void ffi_prep_args(char *stack, extended_cif *ecif);
 
 void ffi_prep_args(char *stack, extended_cif *ecif)
 {
-    register unsigned int i;
-    register void **p_argv;
-    register char *argp;
-    register ffi_type **p_arg;
+    unsigned int i;
+    void **p_argv;
+    char *argp;
+    ffi_type **p_arg;
     
     argp = stack;
     
@@ -266,10 +266,10 @@ static void
 ffi_prep_incoming_args_SYSV(char *stack, void **rvalue, void **avalue,
                             ffi_cif *cif)
 {
-    register unsigned int i;
-    register void **p_argv;
-    register char *argp;
-    register ffi_type **p_arg;
+    unsigned int i;
+    void **p_argv;
+    char *argp;
+    ffi_type **p_arg;
     
     argp = stack;
     

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -452,7 +452,7 @@ newarrayobject(PyTypeObject *type, Py_ssize_t size, struct arraydescr *descr)
 static PyObject *
 getarrayitem(PyObject *op, Py_ssize_t i)
 {
-    register arrayobject *ap;
+    arrayobject *ap;
     assert(array_Check(op));
     ap = (arrayobject *)op;
     assert(i>=0 && i<Py_SIZE(ap));
@@ -1181,8 +1181,8 @@ Byteswap all items of the array.  If the items in the array are not 1, 2,\n\
 static PyObject *
 array_reverse(arrayobject *self, PyObject *unused)
 {
-    register Py_ssize_t itemsize = self->ob_descr->itemsize;
-    register char *p, *q;
+    Py_ssize_t itemsize = self->ob_descr->itemsize;
+    char *p, *q;
     /* little buffer to hold items while swapping */
     char tmp[256];      /* 8 is probably enough -- but why skimp */
     assert((size_t)itemsize <= sizeof(tmp));

--- a/Modules/cgensupport.c
+++ b/Modules/cgensupport.c
@@ -11,7 +11,7 @@
    one argument. */
 
 int
-PyArg_GetObject(register PyObject *args, int nargs, int i, PyObject **p_arg)
+PyArg_GetObject(PyObject *args, int nargs, int i, PyObject **p_arg)
 {
     if (nargs != 1) {
         if (args == NULL || !PyTuple_Check(args) ||
@@ -31,7 +31,7 @@ PyArg_GetObject(register PyObject *args, int nargs, int i, PyObject **p_arg)
 }
 
 int
-PyArg_GetLong(register PyObject *args, int nargs, int i, long *p_arg)
+PyArg_GetLong(PyObject *args, int nargs, int i, long *p_arg)
 {
     if (nargs != 1) {
         if (args == NULL || !PyTuple_Check(args) ||
@@ -49,7 +49,7 @@ PyArg_GetLong(register PyObject *args, int nargs, int i, long *p_arg)
 }
 
 int
-PyArg_GetShort(register PyObject *args, int nargs, int i, short *p_arg)
+PyArg_GetShort(PyObject *args, int nargs, int i, short *p_arg)
 {
     long x;
     if (!PyArg_GetLong(args, nargs, i, &x))
@@ -59,7 +59,7 @@ PyArg_GetShort(register PyObject *args, int nargs, int i, short *p_arg)
 }
 
 static int
-extractdouble(register PyObject *v, double *p_arg)
+extractdouble(PyObject *v, double *p_arg)
 {
     if (v == NULL) {
         /* Fall through to error return at end of function */
@@ -80,7 +80,7 @@ extractdouble(register PyObject *v, double *p_arg)
 }
 
 static int
-extractfloat(register PyObject *v, float *p_arg)
+extractfloat(PyObject *v, float *p_arg)
 {
     if (v == NULL) {
         /* Fall through to error return at end of function */
@@ -101,7 +101,7 @@ extractfloat(register PyObject *v, float *p_arg)
 }
 
 int
-PyArg_GetFloat(register PyObject *args, int nargs, int i, float *p_arg)
+PyArg_GetFloat(PyObject *args, int nargs, int i, float *p_arg)
 {
     PyObject *v;
     float x;

--- a/Modules/dbmmodule.c
+++ b/Modules/dbmmodule.c
@@ -217,7 +217,7 @@ dbm__close(register dbmobject *dp, PyObject *unused)
 static PyObject *
 dbm_keys(register dbmobject *dp, PyObject *unused)
 {
-    register PyObject *v, *item;
+    PyObject *v, *item;
     datum key;
     int err;
 

--- a/Modules/dbmmodule.c
+++ b/Modules/dbmmodule.c
@@ -66,7 +66,7 @@ newdbmobject(char *file, int flags, int mode)
 /* Methods */
 
 static void
-dbm_dealloc(register dbmobject *dp)
+dbm_dealloc(dbmobject *dp)
 {
     if ( dp->di_dbm )
         dbm_close(dp->di_dbm);
@@ -94,7 +94,7 @@ dbm_length(dbmobject *dp)
 }
 
 static PyObject *
-dbm_subscript(dbmobject *dp, register PyObject *key)
+dbm_subscript(dbmobject *dp,PyObject *key)
 {
     datum drec, krec;
     int tmp_size;
@@ -165,7 +165,7 @@ dbm_ass_sub(dbmobject *dp, PyObject *v, PyObject *w)
 }
 
 static int
-dbm_contains(register dbmobject *dp, PyObject *v)
+dbm_contains(dbmobject *dp, PyObject *v)
 {
     datum key, val;
     char *ptr;
@@ -205,7 +205,7 @@ static PyMappingMethods dbm_as_mapping = {
 };
 
 static PyObject *
-dbm__close(register dbmobject *dp, PyObject *unused)
+dbm__close(dbmobject *dp, PyObject *unused)
 {
     if (dp->di_dbm)
         dbm_close(dp->di_dbm);
@@ -215,7 +215,7 @@ dbm__close(register dbmobject *dp, PyObject *unused)
 }
 
 static PyObject *
-dbm_keys(register dbmobject *dp, PyObject *unused)
+dbm_keys(dbmobject *dp, PyObject *unused)
 {
     PyObject *v, *item;
     datum key;
@@ -243,7 +243,7 @@ dbm_keys(register dbmobject *dp, PyObject *unused)
 }
 
 static PyObject *
-dbm_has_key(register dbmobject *dp, PyObject *args)
+dbm_has_key(dbmobject *dp, PyObject *args)
 {
     char *tmp_ptr;
     datum key, val;
@@ -259,7 +259,7 @@ dbm_has_key(register dbmobject *dp, PyObject *args)
 }
 
 static PyObject *
-dbm_get(register dbmobject *dp, PyObject *args)
+dbm_get(dbmobject *dp, PyObject *args)
 {
     datum key, val;
     PyObject *defvalue = Py_None;
@@ -282,7 +282,7 @@ dbm_get(register dbmobject *dp, PyObject *args)
 }
 
 static PyObject *
-dbm_setdefault(register dbmobject *dp, PyObject *args)
+dbm_setdefault(dbmobject *dp, PyObject *args)
 {
     datum key, val;
     PyObject *defvalue = NULL;

--- a/Modules/gdbmmodule.c
+++ b/Modules/gdbmmodule.c
@@ -239,7 +239,7 @@ Get a list of all keys in the database.");
 static PyObject *
 dbm_keys(register dbmobject *dp, PyObject *unused)
 {
-    register PyObject *v, *item;
+    PyObject *v, *item;
     datum key, nextkey;
     int err;
 
@@ -300,7 +300,7 @@ returns the starting key.");
 static PyObject *
 dbm_firstkey(register dbmobject *dp, PyObject *unused)
 {
-    register PyObject *v;
+    PyObject *v;
     datum key;
 
     check_dbmobject_open(dp);
@@ -330,7 +330,7 @@ to create a list in memory that contains them all:\n\
 static PyObject *
 dbm_nextkey(register dbmobject *dp, PyObject *args)
 {
-    register PyObject *v;
+    PyObject *v;
     datum key, nextkey;
 
     if (!PyArg_ParseTuple(args, "s#:nextkey", &key.dptr, &key.dsize))

--- a/Modules/gdbmmodule.c
+++ b/Modules/gdbmmodule.c
@@ -79,7 +79,7 @@ newdbmobject(char *file, int flags, int mode)
 /* Methods */
 
 static void
-dbm_dealloc(register dbmobject *dp)
+dbm_dealloc(dbmobject *dp)
 {
     if (dp->di_dbm)
         gdbm_close(dp->di_dbm);
@@ -112,7 +112,7 @@ dbm_length(dbmobject *dp)
 }
 
 static PyObject *
-dbm_subscript(dbmobject *dp, register PyObject *key)
+dbm_subscript(dbmobject *dp,PyObject *key)
 {
     PyObject *v;
     datum drec, krec;
@@ -179,7 +179,7 @@ dbm_ass_sub(dbmobject *dp, PyObject *v, PyObject *w)
 }
 
 static int
-dbm_contains(register dbmobject *dp, PyObject *arg)
+dbm_contains(dbmobject *dp, PyObject *arg)
 {
     datum key;
 
@@ -223,7 +223,7 @@ PyDoc_STRVAR(dbm_close__doc__,
 Closes the database.");
 
 static PyObject *
-dbm_close(register dbmobject *dp, PyObject *unused)
+dbm_close(dbmobject *dp, PyObject *unused)
 {
     if (dp->di_dbm)
         gdbm_close(dp->di_dbm);
@@ -237,7 +237,7 @@ PyDoc_STRVAR(dbm_keys__doc__,
 Get a list of all keys in the database.");
 
 static PyObject *
-dbm_keys(register dbmobject *dp, PyObject *unused)
+dbm_keys(dbmobject *dp, PyObject *unused)
 {
     PyObject *v, *item;
     datum key, nextkey;
@@ -280,7 +280,7 @@ PyDoc_STRVAR(dbm_has_key__doc__,
 Find out whether or not the database contains a given key.");
 
 static PyObject *
-dbm_has_key(register dbmobject *dp, PyObject *args)
+dbm_has_key(dbmobject *dp, PyObject *args)
 {
     datum key;
 
@@ -298,7 +298,7 @@ hash values, and won't be sorted by the key values. This method\n\
 returns the starting key.");
 
 static PyObject *
-dbm_firstkey(register dbmobject *dp, PyObject *unused)
+dbm_firstkey(dbmobject *dp, PyObject *unused)
 {
     PyObject *v;
     datum key;
@@ -328,7 +328,7 @@ to create a list in memory that contains them all:\n\
           k = db.nextkey(k)");
 
 static PyObject *
-dbm_nextkey(register dbmobject *dp, PyObject *args)
+dbm_nextkey(dbmobject *dp, PyObject *args)
 {
     PyObject *v;
     datum key, nextkey;
@@ -357,7 +357,7 @@ by using this reorganization; otherwise, deleted file space will be\n\
 kept and reused as new (key,value) pairs are added.");
 
 static PyObject *
-dbm_reorganize(register dbmobject *dp, PyObject *unused)
+dbm_reorganize(dbmobject *dp, PyObject *unused)
 {
     check_dbmobject_open(dp);
     errno = 0;
@@ -378,7 +378,7 @@ When the database has been opened in fast mode, this method forces\n\
 any unwritten data to be written to the disk.");
 
 static PyObject *
-dbm_sync(register dbmobject *dp, PyObject *unused)
+dbm_sync(dbmobject *dp, PyObject *unused)
 {
     check_dbmobject_open(dp);
     gdbm_sync(dp->di_dbm);

--- a/Modules/glmodule.c
+++ b/Modules/glmodule.c
@@ -733,10 +733,10 @@ gl_unpackrect(PyObject *self, PyObject *args)
     char *s;
     PyObject *unpacked, *packed;
     int pixcount, packedcount;
-    register unsigned char *p;
-    register unsigned long *parray;
+    unsigned char *p;
+    unsigned long *parray;
     if (!unpacktab_inited) {
-        register int white;
+        int white;
         for (white = 256; --white >= 0; )
             unpacktab[white] = white * 0x010101L;
         unpacktab_inited++;
@@ -770,21 +770,21 @@ gl_unpackrect(PyObject *self, PyObject *args)
     p = (unsigned char *) PyString_AsString(packed);
     if (packfactor == 1 && width*height > 0) {
         /* Just expand bytes to longs */
-        register int x = width * height;
+        int x = width * height;
         do {
             *parray++ = unpacktab[*p++];
         } while (--x >= 0);
     }
     else {
-        register int y;
+        int y;
         for (y = 0; y < height-packfactor+1;
              y += packfactor, parray += packfactor*width) {
-            register int x;
+            int x;
             for (x = 0; x < width-packfactor+1; x += packfactor) {
-                register unsigned long pixel = unpacktab[*p++];
-                register int i;
+                unsigned long pixel = unpacktab[*p++];
+                int i;
                 for (i = packfactor*width; (i-=width) >= 0;) {
-                    register int j;
+                    int j;
                     for (j = packfactor; --j >= 0; )
                         parray[i+x+j] = pixel;
                 }

--- a/Modules/stropmodule.c
+++ b/Modules/stropmodule.c
@@ -946,7 +946,7 @@ PyDoc_STRVAR(translate__doc__,
 static PyObject *
 strop_translate(PyObject *self, PyObject *args)
 {
-    register char *input, *table, *output;
+    char *input, *table, *output;
     Py_ssize_t i;
     int c, changed = 0;
     PyObject *input_obj;
@@ -1027,7 +1027,7 @@ strop_translate(PyObject *self, PyObject *args)
 static Py_ssize_t
 mymemfind(const char *mem, Py_ssize_t len, const char *pat, Py_ssize_t pat_len)
 {
-    register Py_ssize_t ii;
+    Py_ssize_t ii;
 
     /* pattern can not occur in the last pat_len-1 chars */
     len -= pat_len;
@@ -1052,7 +1052,7 @@ mymemfind(const char *mem, Py_ssize_t len, const char *pat, Py_ssize_t pat_len)
 static Py_ssize_t
 mymemcnt(const char *mem, Py_ssize_t len, const char *pat, Py_ssize_t pat_len)
 {
-    register Py_ssize_t offset = 0;
+    Py_ssize_t offset = 0;
     Py_ssize_t nfound = 0;
 
     while (len >= 0) {

--- a/Modules/zlib/crc32.c
+++ b/Modules/zlib/crc32.c
@@ -268,8 +268,8 @@ local unsigned long crc32_little(crc, buf, len)
     const unsigned char FAR *buf;
     z_size_t len;
 {
-    register z_crc_t c;
-    register const z_crc_t FAR *buf4;
+    z_crc_t c;
+    const z_crc_t FAR *buf4;
 
     c = (z_crc_t)crc;
     c = ~c;
@@ -308,8 +308,8 @@ local unsigned long crc32_big(crc, buf, len)
     const unsigned char FAR *buf;
     z_size_t len;
 {
-    register z_crc_t c;
-    register const z_crc_t FAR *buf4;
+    z_crc_t c;
+    const z_crc_t FAR *buf4;
 
     c = ZSWAP32((z_crc_t)crc);
     c = ~c;

--- a/Modules/zlib/deflate.c
+++ b/Modules/zlib/deflate.c
@@ -1238,9 +1238,9 @@ local uInt longest_match(s, cur_match)
     IPos cur_match;                             /* current match */
 {
     unsigned chain_length = s->max_chain_length;/* max hash chain length */
-    register Bytef *scan = s->window + s->strstart; /* current string */
-    register Bytef *match;                      /* matched string */
-    register int len;                           /* length of current match */
+    Bytef *scan = s->window + s->strstart; /* current string */
+    Bytef *match;                      /* matched string */
+    int len;                           /* length of current match */
     int best_len = (int)s->prev_length;         /* best match length so far */
     int nice_match = s->nice_match;             /* stop if match long enough */
     IPos limit = s->strstart > (IPos)MAX_DIST(s) ?
@@ -1255,13 +1255,13 @@ local uInt longest_match(s, cur_match)
     /* Compare two bytes at a time. Note: this is not always beneficial.
      * Try with and without -DUNALIGNED_OK to check.
      */
-    register Bytef *strend = s->window + s->strstart + MAX_MATCH - 1;
-    register ush scan_start = *(ushf*)scan;
-    register ush scan_end   = *(ushf*)(scan+best_len-1);
+    Bytef *strend = s->window + s->strstart + MAX_MATCH - 1;
+    ush scan_start = *(ushf*)scan;
+    ush scan_end   = *(ushf*)(scan+best_len-1);
 #else
-    register Bytef *strend = s->window + s->strstart + MAX_MATCH;
-    register Byte scan_end1  = scan[best_len-1];
-    register Byte scan_end   = scan[best_len];
+    Bytef *strend = s->window + s->strstart + MAX_MATCH;
+    Byte scan_end1  = scan[best_len-1];
+    Byte scan_end   = scan[best_len];
 #endif
 
     /* The code is optimized for HASH_BITS >= 8 and MAX_MATCH-2 multiple of 16.
@@ -1386,10 +1386,10 @@ local uInt longest_match(s, cur_match)
     deflate_state *s;
     IPos cur_match;                             /* current match */
 {
-    register Bytef *scan = s->window + s->strstart; /* current string */
-    register Bytef *match;                       /* matched string */
-    register int len;                           /* length of current match */
-    register Bytef *strend = s->window + s->strstart + MAX_MATCH;
+    Bytef *scan = s->window + s->strstart; /* current string */
+    Bytef *match;                       /* matched string */
+    int len;                           /* length of current match */
+    Bytef *strend = s->window + s->strstart + MAX_MATCH;
 
     /* The code is optimized for HASH_BITS >= 8 and MAX_MATCH-2 multiple of 16.
      * It is easy to get rid of this optimization if necessary.

--- a/Modules/zlib/trees.c
+++ b/Modules/zlib/trees.c
@@ -1159,7 +1159,7 @@ local unsigned bi_reverse(code, len)
     unsigned code; /* the value to invert */
     int len;       /* its bit length */
 {
-    register unsigned res = 0;
+    unsigned res = 0;
     do {
         res |= code & 1;
         code >>= 1, res <<= 1;

--- a/Objects/bufferobject.c
+++ b/Objects/bufferobject.c
@@ -309,9 +309,9 @@ buffer_hash(PyBufferObject *self)
 {
     void *ptr;
     Py_ssize_t size;
-    register Py_ssize_t len;
-    register unsigned char *p;
-    register long x;
+    Py_ssize_t len;
+    unsigned char *p;
+    long x;
 
     if ( self->b_hash != -1 )
         return self->b_hash;
@@ -432,7 +432,7 @@ static PyObject *
 buffer_repeat(PyBufferObject *self, Py_ssize_t count)
 {
     PyObject *ob;
-    register char *p;
+    char *p;
     void *ptr;
     Py_ssize_t size;
 

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -938,9 +938,9 @@ bytearray_repr(PyByteArrayObject *self)
         return NULL;
     }
     else {
-        register Py_ssize_t i;
-        register char c;
-        register char *p;
+        Py_ssize_t i;
+        char c;
+        char *p;
         int quote;
 
         /* Figure out which quote to use; single is preferred */
@@ -1441,9 +1441,9 @@ table, which must be a bytes object of length 256.");
 static PyObject *
 bytearray_translate(PyByteArrayObject *self, PyObject *args)
 {
-    register char *input, *output;
-    register const char *table;
-    register Py_ssize_t i, c;
+    char *input, *output;
+    const char *table;
+    Py_ssize_t i, c;
     PyObject *input_obj = (PyObject*)self;
     const char *output_start;
     Py_ssize_t inlen;

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -10,9 +10,9 @@ and there is at least one character in B, False otherwise.");
 PyObject*
 _Py_bytes_isspace(const char *cptr, Py_ssize_t len)
 {
-    register const unsigned char *p
+    const unsigned char *p
         = (unsigned char *) cptr;
-    register const unsigned char *e;
+    const unsigned char *e;
 
     /* Shortcut for single character strings */
     if (len == 1 && Py_ISSPACE(*p))
@@ -40,9 +40,9 @@ and there is at least one character in B, False otherwise.");
 PyObject*
 _Py_bytes_isalpha(const char *cptr, Py_ssize_t len)
 {
-    register const unsigned char *p
+    const unsigned char *p
         = (unsigned char *) cptr;
-    register const unsigned char *e;
+    const unsigned char *e;
 
     /* Shortcut for single character strings */
     if (len == 1 && Py_ISALPHA(*p))
@@ -70,9 +70,9 @@ and there is at least one character in B, False otherwise.");
 PyObject*
 _Py_bytes_isalnum(const char *cptr, Py_ssize_t len)
 {
-    register const unsigned char *p
+    const unsigned char *p
         = (unsigned char *) cptr;
-    register const unsigned char *e;
+    const unsigned char *e;
 
     /* Shortcut for single character strings */
     if (len == 1 && Py_ISALNUM(*p))
@@ -100,9 +100,9 @@ and there is at least one character in B, False otherwise.");
 PyObject*
 _Py_bytes_isdigit(const char *cptr, Py_ssize_t len)
 {
-    register const unsigned char *p
+    const unsigned char *p
         = (unsigned char *) cptr;
-    register const unsigned char *e;
+    const unsigned char *e;
 
     /* Shortcut for single character strings */
     if (len == 1 && Py_ISDIGIT(*p))
@@ -130,9 +130,9 @@ at least one cased character in B, False otherwise.");
 PyObject*
 _Py_bytes_islower(const char *cptr, Py_ssize_t len)
 {
-    register const unsigned char *p
+    const unsigned char *p
         = (unsigned char *) cptr;
-    register const unsigned char *e;
+    const unsigned char *e;
     int cased;
 
     /* Shortcut for single character strings */
@@ -164,9 +164,9 @@ at least one cased character in B, False otherwise.");
 PyObject*
 _Py_bytes_isupper(const char *cptr, Py_ssize_t len)
 {
-    register const unsigned char *p
+    const unsigned char *p
         = (unsigned char *) cptr;
-    register const unsigned char *e;
+    const unsigned char *e;
     int cased;
 
     /* Shortcut for single character strings */
@@ -200,9 +200,9 @@ otherwise.");
 PyObject*
 _Py_bytes_istitle(const char *cptr, Py_ssize_t len)
 {
-    register const unsigned char *p
+    const unsigned char *p
         = (unsigned char *) cptr;
-    register const unsigned char *e;
+    const unsigned char *e;
     int cased, previous_is_cased;
 
     /* Shortcut for single character strings */
@@ -217,7 +217,7 @@ _Py_bytes_istitle(const char *cptr, Py_ssize_t len)
     cased = 0;
     previous_is_cased = 0;
     for (; p < e; p++) {
-        register const unsigned char ch = *p;
+        const unsigned char ch = *p;
 
         if (Py_ISUPPER(ch)) {
             if (previous_is_cased)

--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -224,8 +224,8 @@ class_lookup(PyClassObject *cp, PyObject *name, PyClassObject **pclass)
 static PyObject *
 class_getattr(register PyClassObject *op, PyObject *name)
 {
-    register PyObject *v;
-    register char *sname;
+    PyObject *v;
+    char *sname;
     PyClassObject *klass;
     descrgetfunc f;
 
@@ -549,7 +549,7 @@ PyInstance_NewRaw(PyObject *klass, PyObject *dict)
 PyObject *
 PyInstance_New(PyObject *klass, PyObject *arg, PyObject *kw)
 {
-    register PyInstanceObject *inst;
+    PyInstanceObject *inst;
     PyObject *init;
     static PyObject *initstr;
 
@@ -708,8 +708,8 @@ instance_dealloc(register PyInstanceObject *inst)
 static PyObject *
 instance_getattr1(register PyInstanceObject *inst, PyObject *name)
 {
-    register PyObject *v;
-    register char *sname;
+    PyObject *v;
+    char *sname;
 
     if (!PyString_Check(name)) {
         PyErr_SetString(PyExc_TypeError, "attribute name must be a string");
@@ -744,7 +744,7 @@ instance_getattr1(register PyInstanceObject *inst, PyObject *name)
 static PyObject *
 instance_getattr2(register PyInstanceObject *inst, PyObject *name)
 {
-    register PyObject *v;
+    PyObject *v;
     PyClassObject *klass;
     descrgetfunc f;
 
@@ -770,7 +770,7 @@ instance_getattr2(register PyInstanceObject *inst, PyObject *name)
 static PyObject *
 instance_getattr(register PyInstanceObject *inst, PyObject *name)
 {
-    register PyObject *func, *res;
+    PyObject *func, *res;
     res = instance_getattr1(inst, name);
     if (res == NULL && (func = inst->in_class->cl_getattr) != NULL) {
         PyObject *args;
@@ -2252,7 +2252,7 @@ PyTypeObject PyInstance_Type = {
 PyObject *
 PyMethod_New(PyObject *func, PyObject *self, PyObject *klass)
 {
-    register PyMethodObject *im;
+    PyMethodObject *im;
     im = free_list;
     if (im != NULL) {
         free_list = (PyMethodObject *)(im->im_self);

--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -222,7 +222,7 @@ class_lookup(PyClassObject *cp, PyObject *name, PyClassObject **pclass)
 }
 
 static PyObject *
-class_getattr(register PyClassObject *op, PyObject *name)
+class_getattr(PyClassObject *op, PyObject *name)
 {
     PyObject *v;
     char *sname;
@@ -628,7 +628,7 @@ instance_new(PyTypeObject* type, PyObject* args, PyObject *kw)
 
 
 static void
-instance_dealloc(register PyInstanceObject *inst)
+instance_dealloc(PyInstanceObject *inst)
 {
     PyObject *error_type, *error_value, *error_traceback;
     PyObject *del;
@@ -706,7 +706,7 @@ instance_dealloc(register PyInstanceObject *inst)
 }
 
 static PyObject *
-instance_getattr1(register PyInstanceObject *inst, PyObject *name)
+instance_getattr1(PyInstanceObject *inst, PyObject *name)
 {
     PyObject *v;
     char *sname;
@@ -742,7 +742,7 @@ instance_getattr1(register PyInstanceObject *inst, PyObject *name)
 }
 
 static PyObject *
-instance_getattr2(register PyInstanceObject *inst, PyObject *name)
+instance_getattr2(PyInstanceObject *inst, PyObject *name)
 {
     PyObject *v;
     PyClassObject *klass;
@@ -768,7 +768,7 @@ instance_getattr2(register PyInstanceObject *inst, PyObject *name)
 }
 
 static PyObject *
-instance_getattr(register PyInstanceObject *inst, PyObject *name)
+instance_getattr(PyInstanceObject *inst, PyObject *name)
 {
     PyObject *func, *res;
     res = instance_getattr1(inst, name);
@@ -2379,7 +2379,7 @@ instancemethod_new(PyTypeObject* type, PyObject* args, PyObject *kw)
 }
 
 static void
-instancemethod_dealloc(register PyMethodObject *im)
+instancemethod_dealloc(PyMethodObject *im)
 {
     _PyObject_GC_UNTRACK(im);
     if (im->im_weakreflist != NULL)

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -233,7 +233,7 @@ complex_subtype_from_c_complex(PyTypeObject *type, Py_complex cval)
 PyObject *
 PyComplex_FromCComplex(Py_complex cval)
 {
-    register PyComplexObject *op;
+    PyComplexObject *op;
 
     /* Inline PyObject_New */
     op = (PyComplexObject *) PyObject_MALLOC(sizeof(PyComplexObject));

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -317,7 +317,7 @@ the caller can (if it wishes) add the <key, value> pair to the returned
 PyDictEntry*.
 */
 static PyDictEntry *
-lookdict(PyDictObject *mp, PyObject *key, register long hash)
+lookdict(PyDictObject *mp, PyObject *key,long hash)
 {
     size_t i;
     size_t perturb;
@@ -405,7 +405,7 @@ lookdict(PyDictObject *mp, PyObject *key, register long hash)
  * This is valuable because dicts with only string keys are very common.
  */
 static PyDictEntry *
-lookdict_string(PyDictObject *mp, PyObject *key, register long hash)
+lookdict_string(PyDictObject *mp, PyObject *key,long hash)
 {
     size_t i;
     size_t perturb;
@@ -507,7 +507,7 @@ Internal routine to insert a new item into the table when you have entry object.
 Used by insertdict.
 */
 static int
-insertdict_by_entry(register PyDictObject *mp, PyObject *key, long hash,
+insertdict_by_entry(PyDictObject *mp, PyObject *key, long hash,
                     PyDictEntry *ep, PyObject *value)
 {
     PyObject *old_value;
@@ -542,7 +542,7 @@ Eats a reference to key and one to value.
 Returns -1 if an error occurred, or 0 on success.
 */
 static int
-insertdict(register PyDictObject *mp, PyObject *key, long hash, PyObject *value)
+insertdict(PyDictObject *mp, PyObject *key, long hash, PyObject *value)
 {
     PyDictEntry *ep;
 
@@ -565,7 +565,7 @@ Note that no refcounts are changed by this routine; if needed, the caller
 is responsible for incref'ing `key` and `value`.
 */
 static void
-insertdict_clean(register PyDictObject *mp, PyObject *key, long hash,
+insertdict_clean(PyDictObject *mp, PyObject *key, long hash,
                  PyObject *value)
 {
     size_t i;
@@ -780,7 +780,7 @@ _PyDict_GetItemWithError(PyObject *op, PyObject *key)
 }
 
 static int
-dict_set_item_by_hash_or_entry(register PyObject *op, PyObject *key,
+dict_set_item_by_hash_or_entry(PyObject *op, PyObject *key,
                                long hash, PyDictEntry *ep, PyObject *value)
 {
     PyDictObject *mp;
@@ -825,7 +825,7 @@ dict_set_item_by_hash_or_entry(register PyObject *op, PyObject *key,
  * remove them.
  */
 int
-PyDict_SetItem(register PyObject *op, PyObject *key, PyObject *value)
+PyDict_SetItem(PyObject *op, PyObject *key, PyObject *value)
 {
     long hash;
 
@@ -1072,7 +1072,7 @@ _PyDict_Next(PyObject *op, Py_ssize_t *ppos, PyObject **pkey, PyObject **pvalue,
 /* Methods */
 
 static void
-dict_dealloc(register PyDictObject *mp)
+dict_dealloc(PyDictObject *mp)
 {
     PyDictEntry *ep;
     Py_ssize_t fill = mp->ma_fill;
@@ -1095,7 +1095,7 @@ dict_dealloc(register PyDictObject *mp)
 }
 
 static int
-dict_print(register PyDictObject *mp, register FILE *fp, register int flags)
+dict_print(PyDictObject *mp,FILE *fp,int flags)
 {
     Py_ssize_t i;
     Py_ssize_t any;
@@ -1236,7 +1236,7 @@ dict_length(PyDictObject *mp)
 }
 
 static PyObject *
-dict_subscript(PyDictObject *mp, register PyObject *key)
+dict_subscript(PyDictObject *mp,PyObject *key)
 {
     PyObject *v;
     long hash;
@@ -1293,7 +1293,7 @@ static PyMappingMethods dict_as_mapping = {
 };
 
 static PyObject *
-dict_keys(register PyDictObject *mp)
+dict_keys(PyDictObject *mp)
 {
     PyObject *v;
     Py_ssize_t i, j;
@@ -1327,7 +1327,7 @@ dict_keys(register PyDictObject *mp)
 }
 
 static PyObject *
-dict_values(register PyDictObject *mp)
+dict_values(PyDictObject *mp)
 {
     PyObject *v;
     Py_ssize_t i, j;
@@ -1361,7 +1361,7 @@ dict_values(register PyDictObject *mp)
 }
 
 static PyObject *
-dict_items(register PyDictObject *mp)
+dict_items(PyDictObject *mp)
 {
     PyObject *v;
     Py_ssize_t i, j, n;
@@ -1726,7 +1726,7 @@ PyDict_Merge(PyObject *a, PyObject *b, int override)
 }
 
 static PyObject *
-dict_copy(register PyDictObject *mp)
+dict_copy(PyDictObject *mp)
 {
     return PyDict_Copy((PyObject*)mp);
 }
@@ -1988,7 +1988,7 @@ dict_richcompare(PyObject *v, PyObject *w, int op)
  }
 
 static PyObject *
-dict_contains(register PyDictObject *mp, PyObject *key)
+dict_contains(PyDictObject *mp, PyObject *key)
 {
     long hash;
     PyDictEntry *ep;
@@ -2006,7 +2006,7 @@ dict_contains(register PyDictObject *mp, PyObject *key)
 }
 
 static PyObject *
-dict_has_key(register PyDictObject *mp, PyObject *key)
+dict_has_key(PyDictObject *mp, PyObject *key)
 {
     if (PyErr_WarnPy3k("dict.has_key() not supported in 3.x; "
                        "use the in operator", 1) < 0)
@@ -2015,7 +2015,7 @@ dict_has_key(register PyDictObject *mp, PyObject *key)
 }
 
 static PyObject *
-dict_get(register PyDictObject *mp, PyObject *args)
+dict_get(PyDictObject *mp, PyObject *args)
 {
     PyObject *key;
     PyObject *failobj = Py_None;
@@ -2044,7 +2044,7 @@ dict_get(register PyDictObject *mp, PyObject *args)
 
 
 static PyObject *
-dict_setdefault(register PyDictObject *mp, PyObject *args)
+dict_setdefault(PyDictObject *mp, PyObject *args)
 {
     PyObject *key;
     PyObject *failobj = Py_None;
@@ -2076,7 +2076,7 @@ dict_setdefault(register PyDictObject *mp, PyObject *args)
 
 
 static PyObject *
-dict_clear(register PyDictObject *mp)
+dict_clear(PyDictObject *mp)
 {
     PyDict_Clear((PyObject *)mp);
     Py_RETURN_NONE;

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -240,7 +240,7 @@ PyDict_Fini(void)
 PyObject *
 PyDict_New(void)
 {
-    register PyDictObject *mp;
+    PyDictObject *mp;
     if (dummy == NULL) { /* Auto-initialize dummy */
         dummy = PyString_FromString("<dummy key>");
         if (dummy == NULL)
@@ -319,13 +319,13 @@ PyDictEntry*.
 static PyDictEntry *
 lookdict(PyDictObject *mp, PyObject *key, register long hash)
 {
-    register size_t i;
-    register size_t perturb;
-    register PyDictEntry *freeslot;
-    register size_t mask = (size_t)mp->ma_mask;
+    size_t i;
+    size_t perturb;
+    PyDictEntry *freeslot;
+    size_t mask = (size_t)mp->ma_mask;
     PyDictEntry *ep0 = mp->ma_table;
-    register PyDictEntry *ep;
-    register int cmp;
+    PyDictEntry *ep;
+    int cmp;
     PyObject *startkey;
 
     i = (size_t)hash & mask;
@@ -407,12 +407,12 @@ lookdict(PyDictObject *mp, PyObject *key, register long hash)
 static PyDictEntry *
 lookdict_string(PyDictObject *mp, PyObject *key, register long hash)
 {
-    register size_t i;
-    register size_t perturb;
-    register PyDictEntry *freeslot;
-    register size_t mask = (size_t)mp->ma_mask;
+    size_t i;
+    size_t perturb;
+    PyDictEntry *freeslot;
+    size_t mask = (size_t)mp->ma_mask;
     PyDictEntry *ep0 = mp->ma_table;
-    register PyDictEntry *ep;
+    PyDictEntry *ep;
 
     /* Make sure this function doesn't have to handle non-string keys,
        including subclasses of str; e.g., one reason to subclass
@@ -544,7 +544,7 @@ Returns -1 if an error occurred, or 0 on success.
 static int
 insertdict(register PyDictObject *mp, PyObject *key, long hash, PyObject *value)
 {
-    register PyDictEntry *ep;
+    PyDictEntry *ep;
 
     assert(mp->ma_lookup != NULL);
     ep = mp->ma_lookup(mp, key, hash);
@@ -568,11 +568,11 @@ static void
 insertdict_clean(register PyDictObject *mp, PyObject *key, long hash,
                  PyObject *value)
 {
-    register size_t i;
-    register size_t perturb;
-    register size_t mask = (size_t)mp->ma_mask;
+    size_t i;
+    size_t perturb;
+    size_t mask = (size_t)mp->ma_mask;
     PyDictEntry *ep0 = mp->ma_table;
-    register PyDictEntry *ep;
+    PyDictEntry *ep;
 
     MAINTAIN_TRACKING(mp, key, value);
     i = hash & mask;
@@ -783,8 +783,8 @@ static int
 dict_set_item_by_hash_or_entry(register PyObject *op, PyObject *key,
                                long hash, PyDictEntry *ep, PyObject *value)
 {
-    register PyDictObject *mp;
-    register Py_ssize_t n_used;
+    PyDictObject *mp;
+    Py_ssize_t n_used;
 
     mp = (PyDictObject *)op;
     assert(mp->ma_fill <= mp->ma_mask);  /* at least one empty slot */
@@ -827,7 +827,7 @@ dict_set_item_by_hash_or_entry(register PyObject *op, PyObject *key,
 int
 PyDict_SetItem(register PyObject *op, PyObject *key, PyObject *value)
 {
-    register long hash;
+    long hash;
 
     if (!PyDict_Check(op)) {
         PyErr_BadInternalCall();
@@ -867,9 +867,9 @@ delitem_common(PyDictObject *mp, PyDictEntry *ep)
 int
 PyDict_DelItem(PyObject *op, PyObject *key)
 {
-    register PyDictObject *mp;
-    register long hash;
-    register PyDictEntry *ep;
+    PyDictObject *mp;
+    long hash;
+    PyDictEntry *ep;
 
     if (!PyDict_Check(op)) {
         PyErr_BadInternalCall();
@@ -898,9 +898,9 @@ int
 _PyDict_DelItemIf(PyObject *op, PyObject *key,
                   int (*predicate)(PyObject *value))
 {
-    register PyDictObject *mp;
-    register long hash;
-    register PyDictEntry *ep;
+    PyDictObject *mp;
+    long hash;
+    PyDictEntry *ep;
     int res;
 
     if (!PyDict_Check(op)) {
@@ -1018,9 +1018,9 @@ PyDict_Clear(PyObject *op)
 int
 PyDict_Next(PyObject *op, Py_ssize_t *ppos, PyObject **pkey, PyObject **pvalue)
 {
-    register Py_ssize_t i;
-    register Py_ssize_t mask;
-    register PyDictEntry *ep;
+    Py_ssize_t i;
+    Py_ssize_t mask;
+    PyDictEntry *ep;
 
     if (!PyDict_Check(op))
         return 0;
@@ -1045,9 +1045,9 @@ PyDict_Next(PyObject *op, Py_ssize_t *ppos, PyObject **pkey, PyObject **pvalue)
 int
 _PyDict_Next(PyObject *op, Py_ssize_t *ppos, PyObject **pkey, PyObject **pvalue, long *phash)
 {
-    register Py_ssize_t i;
-    register Py_ssize_t mask;
-    register PyDictEntry *ep;
+    Py_ssize_t i;
+    Py_ssize_t mask;
+    PyDictEntry *ep;
 
     if (!PyDict_Check(op))
         return 0;
@@ -1074,7 +1074,7 @@ _PyDict_Next(PyObject *op, Py_ssize_t *ppos, PyObject **pkey, PyObject **pvalue,
 static void
 dict_dealloc(register PyDictObject *mp)
 {
-    register PyDictEntry *ep;
+    PyDictEntry *ep;
     Py_ssize_t fill = mp->ma_fill;
     PyObject_GC_UnTrack(mp);
     Py_TRASHCAN_SAFE_BEGIN(mp)
@@ -1097,8 +1097,8 @@ dict_dealloc(register PyDictObject *mp)
 static int
 dict_print(register PyDictObject *mp, register FILE *fp, register int flags)
 {
-    register Py_ssize_t i;
-    register Py_ssize_t any;
+    Py_ssize_t i;
+    Py_ssize_t any;
     int status;
 
     status = Py_ReprEnter((PyObject*)mp);
@@ -1295,8 +1295,8 @@ static PyMappingMethods dict_as_mapping = {
 static PyObject *
 dict_keys(register PyDictObject *mp)
 {
-    register PyObject *v;
-    register Py_ssize_t i, j;
+    PyObject *v;
+    Py_ssize_t i, j;
     PyDictEntry *ep;
     Py_ssize_t mask, n;
 
@@ -1329,8 +1329,8 @@ dict_keys(register PyDictObject *mp)
 static PyObject *
 dict_values(register PyDictObject *mp)
 {
-    register PyObject *v;
-    register Py_ssize_t i, j;
+    PyObject *v;
+    Py_ssize_t i, j;
     PyDictEntry *ep;
     Py_ssize_t mask, n;
 
@@ -1363,8 +1363,8 @@ dict_values(register PyDictObject *mp)
 static PyObject *
 dict_items(register PyDictObject *mp)
 {
-    register PyObject *v;
-    register Py_ssize_t i, j, n;
+    PyObject *v;
+    Py_ssize_t i, j, n;
     Py_ssize_t mask;
     PyObject *item, *key, *value;
     PyDictEntry *ep;
@@ -1631,8 +1631,8 @@ PyDict_Update(PyObject *a, PyObject *b)
 int
 PyDict_Merge(PyObject *a, PyObject *b, int override)
 {
-    register PyDictObject *mp, *other;
-    register Py_ssize_t i;
+    PyDictObject *mp, *other;
+    Py_ssize_t i;
     PyDictEntry *entry;
 
     /* We accept for the argument either a concrete dictionary object,
@@ -2608,8 +2608,8 @@ static PyMethodDef dictiter_methods[] = {
 static PyObject *dictiter_iternextkey(dictiterobject *di)
 {
     PyObject *key;
-    register Py_ssize_t i, mask;
-    register PyDictEntry *ep;
+    Py_ssize_t i, mask;
+    PyDictEntry *ep;
     PyDictObject *d = di->di_dict;
 
     if (d == NULL)
@@ -2680,8 +2680,8 @@ PyTypeObject PyDictIterKey_Type = {
 static PyObject *dictiter_iternextvalue(dictiterobject *di)
 {
     PyObject *value;
-    register Py_ssize_t i, mask;
-    register PyDictEntry *ep;
+    Py_ssize_t i, mask;
+    PyDictEntry *ep;
     PyDictObject *d = di->di_dict;
 
     if (d == NULL)
@@ -2752,8 +2752,8 @@ PyTypeObject PyDictIterValue_Type = {
 static PyObject *dictiter_iternextitem(dictiterobject *di)
 {
     PyObject *key, *value, *result;
-    register Py_ssize_t i, mask;
-    register PyDictEntry *ep;
+    Py_ssize_t i, mask;
+    PyDictEntry *ep;
     PyDictObject *d = di->di_dict;
 
     if (d == NULL)

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -141,7 +141,7 @@ PyFloat_GetInfo(void)
 PyObject *
 PyFloat_FromDouble(double fval)
 {
-    register PyFloatObject *op;
+    PyFloatObject *op;
     if (free_list == NULL) {
         if ((free_list = fill_free_list()) == NULL)
             return NULL;
@@ -310,7 +310,7 @@ PyFloat_AsDouble(PyObject *op)
 static int
 convert_to_double(PyObject **v, double *dbl)
 {
-    register PyObject *obj = *v;
+    PyObject *obj = *v;
 
     if (PyInt_Check(obj)) {
         *dbl = (double)PyInt_AS_LONG(obj);

--- a/Objects/intobject.c
+++ b/Objects/intobject.c
@@ -86,7 +86,7 @@ Py_ssize_t quick_neg_int_allocs;
 PyObject *
 PyInt_FromLong(long ival)
 {
-    register PyIntObject *v;
+    PyIntObject *v;
 #if NSMALLNEGINTS + NSMALLPOSINTS > 0
     if (-NSMALLNEGINTS <= ival && ival < NSMALLPOSINTS) {
         v = small_ints[ival + NSMALLNEGINTS];
@@ -449,8 +449,8 @@ int_print(PyIntObject *v, FILE *fp, int flags)
 static int
 int_compare(PyIntObject *v, PyIntObject *w)
 {
-    register long i = v->ob_ival;
-    register long j = w->ob_ival;
+    long i = v->ob_ival;
+    long j = w->ob_ival;
     return (i < j) ? -1 : (i > j) ? 1 : 0;
 }
 
@@ -468,7 +468,7 @@ int_hash(PyIntObject *v)
 static PyObject *
 int_add(PyIntObject *v, PyIntObject *w)
 {
-    register long a, b, x;
+    long a, b, x;
     CONVERT_TO_LONG(v, a);
     CONVERT_TO_LONG(w, b);
     /* casts in the line below avoid undefined behaviour on overflow */
@@ -481,7 +481,7 @@ int_add(PyIntObject *v, PyIntObject *w)
 static PyObject *
 int_sub(PyIntObject *v, PyIntObject *w)
 {
-    register long a, b, x;
+    long a, b, x;
     CONVERT_TO_LONG(v, a);
     CONVERT_TO_LONG(w, b);
     /* casts in the line below avoid undefined behaviour on overflow */
@@ -725,7 +725,7 @@ int_divmod(PyIntObject *x, PyIntObject *y)
 static PyObject *
 int_pow(PyIntObject *v, PyIntObject *w, PyIntObject *z)
 {
-    register long iv, iw, iz=0, ix, temp, prev;
+    long iv, iw, iz=0, ix, temp, prev;
     CONVERT_TO_LONG(v, iv);
     CONVERT_TO_LONG(w, iw);
     if (iw < 0) {
@@ -810,7 +810,7 @@ int_pow(PyIntObject *v, PyIntObject *w, PyIntObject *z)
 static PyObject *
 int_neg(PyIntObject *v)
 {
-    register long a;
+    long a;
     a = v->ob_ival;
     /* check for overflow */
     if (UNARY_NEG_WOULD_OVERFLOW(a)) {
@@ -895,7 +895,7 @@ int_lshift(PyIntObject *v, PyIntObject *w)
 static PyObject *
 int_rshift(PyIntObject *v, PyIntObject *w)
 {
-    register long a, b;
+    long a, b;
     CONVERT_TO_LONG(v, a);
     CONVERT_TO_LONG(w, b);
     if (b < 0) {
@@ -919,7 +919,7 @@ int_rshift(PyIntObject *v, PyIntObject *w)
 static PyObject *
 int_and(PyIntObject *v, PyIntObject *w)
 {
-    register long a, b;
+    long a, b;
     CONVERT_TO_LONG(v, a);
     CONVERT_TO_LONG(w, b);
     return PyInt_FromLong(a & b);
@@ -928,7 +928,7 @@ int_and(PyIntObject *v, PyIntObject *w)
 static PyObject *
 int_xor(PyIntObject *v, PyIntObject *w)
 {
-    register long a, b;
+    long a, b;
     CONVERT_TO_LONG(v, a);
     CONVERT_TO_LONG(w, b);
     return PyInt_FromLong(a ^ b);
@@ -937,7 +937,7 @@ int_xor(PyIntObject *v, PyIntObject *w)
 static PyObject *
 int_or(PyIntObject *v, PyIntObject *w)
 {
-    register long a, b;
+    long a, b;
     CONVERT_TO_LONG(v, a);
     CONVERT_TO_LONG(w, b);
     return PyInt_FromLong(a | b);

--- a/Objects/intobject.c
+++ b/Objects/intobject.c
@@ -140,7 +140,7 @@ int_dealloc(PyIntObject *v)
 }
 
 long
-PyInt_AsLong(register PyObject *op)
+PyInt_AsLong(PyObject *op)
 {
     PyNumberMethods *nb;
     PyIntObject *io;
@@ -200,7 +200,7 @@ _PyInt_AsInt(PyObject *obj)
 }
 
 Py_ssize_t
-PyInt_AsSsize_t(register PyObject *op)
+PyInt_AsSsize_t(PyObject *op)
 {
 #if SIZEOF_SIZE_T != SIZEOF_LONG
     PyNumberMethods *nb;
@@ -259,7 +259,7 @@ PyInt_AsSsize_t(register PyObject *op)
 }
 
 unsigned long
-PyInt_AsUnsignedLongMask(register PyObject *op)
+PyInt_AsUnsignedLongMask(PyObject *op)
 {
     PyNumberMethods *nb;
     PyIntObject *io;
@@ -304,7 +304,7 @@ PyInt_AsUnsignedLongMask(register PyObject *op)
 
 #ifdef HAVE_LONG_LONG
 unsigned PY_LONG_LONG
-PyInt_AsUnsignedLongLongMask(register PyObject *op)
+PyInt_AsUnsignedLongLongMask(PyObject *op)
 {
     PyNumberMethods *nb;
     PyIntObject *io;
@@ -576,7 +576,7 @@ enum divmod_result {
 };
 
 static enum divmod_result
-i_divmod(register long x, register long y,
+i_divmod(long x,long y,
          long *p_xdivy, long *p_xmody)
 {
     long xdivy, xmody;

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -197,10 +197,10 @@ PyList_GetItem(PyObject *op, Py_ssize_t i)
 
 int
 PyList_SetItem(register PyObject *op, register Py_ssize_t i,
-               register PyObject *newitem)
+               PyObject *newitem)
 {
-    register PyObject *olditem;
-    register PyObject **p;
+    PyObject *olditem;
+    PyObject **p;
     if (!PyList_Check(op)) {
         Py_XDECREF(newitem);
         PyErr_BadInternalCall();
@@ -1055,9 +1055,9 @@ static int
 binarysort(PyObject **lo, PyObject **hi, PyObject **start, PyObject *compare)
      /* compare -- comparison function object, or NULL for default */
 {
-    register Py_ssize_t k;
-    register PyObject **l, **p, **r;
-    register PyObject *pivot;
+    Py_ssize_t k;
+    PyObject **l, **p, **r;
+    PyObject *pivot;
 
     assert(lo <= start && start <= hi);
     /* assert [lo, start) is sorted */

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -196,7 +196,7 @@ PyList_GetItem(PyObject *op, Py_ssize_t i)
 }
 
 int
-PyList_SetItem(register PyObject *op, register Py_ssize_t i,
+PyList_SetItem(PyObject *op,Py_ssize_t i,
                PyObject *newitem)
 {
     PyObject *olditem;

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -232,7 +232,7 @@ long
 PyLong_AsLongAndOverflow(PyObject *vv, int *overflow)
 {
     /* This version by Tim Peters */
-    register PyLongObject *v;
+    PyLongObject *v;
     unsigned long x, prev;
     long res;
     Py_ssize_t i;
@@ -362,7 +362,7 @@ _PyLong_AsInt(PyObject *obj)
 
 Py_ssize_t
 PyLong_AsSsize_t(PyObject *vv) {
-    register PyLongObject *v;
+    PyLongObject *v;
     size_t x, prev;
     Py_ssize_t i;
     int sign;
@@ -408,7 +408,7 @@ PyLong_AsSsize_t(PyObject *vv) {
 unsigned long
 PyLong_AsUnsignedLong(PyObject *vv)
 {
-    register PyLongObject *v;
+    PyLongObject *v;
     unsigned long x, prev;
     Py_ssize_t i;
 
@@ -452,7 +452,7 @@ PyLong_AsUnsignedLong(PyObject *vv)
 unsigned long
 PyLong_AsUnsignedLongMask(PyObject *vv)
 {
-    register PyLongObject *v;
+    PyLongObject *v;
     unsigned long x;
     Py_ssize_t i;
     int sign;
@@ -1015,7 +1015,7 @@ PyLong_AsUnsignedLongLong(PyObject *vv)
 unsigned PY_LONG_LONG
 PyLong_AsUnsignedLongLongMask(PyObject *vv)
 {
-    register PyLongObject *v;
+    PyLongObject *v;
     unsigned PY_LONG_LONG x;
     Py_ssize_t i;
     int sign;
@@ -1050,7 +1050,7 @@ PY_LONG_LONG
 PyLong_AsLongLongAndOverflow(PyObject *vv, int *overflow)
 {
     /* This version by Tim Peters */
-    register PyLongObject *v;
+    PyLongObject *v;
     unsigned PY_LONG_LONG x, prev;
     PY_LONG_LONG res;
     Py_ssize_t i;
@@ -1454,7 +1454,7 @@ long_to_decimal_string(PyObject *aa, int addL)
 PyAPI_FUNC(PyObject *)
 _PyLong_Format(PyObject *aa, int base, int addL, int newstyle)
 {
-    register PyLongObject *a = (PyLongObject *)aa;
+    PyLongObject *a = (PyLongObject *)aa;
     PyStringObject *str;
     Py_ssize_t i, sz;
     Py_ssize_t size_a;
@@ -1850,7 +1850,7 @@ that triggers it(!).  Instead the code was tested by artificially allocating
 just 1 digit at the start, so that the copying code was exercised for every
 digit beyond the first.
 ***/
-        register twodigits c;           /* current input character */
+        twodigits c;           /* current input character */
         Py_ssize_t size_z;
         int i;
         int convwidth;

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -44,7 +44,7 @@
    of the algorithms used, this could save at most be one word anyway. */
 
 static PyLongObject *
-long_normalize(register PyLongObject *v)
+long_normalize(PyLongObject *v)
 {
     Py_ssize_t j = ABS(Py_SIZE(v));
     Py_ssize_t i = j;

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1611,8 +1611,8 @@ PyObject_Not(PyObject *v)
 int
 PyNumber_CoerceEx(PyObject **pv, PyObject **pw)
 {
-    register PyObject *v = *pv;
-    register PyObject *w = *pw;
+    PyObject *v = *pv;
+    PyObject *w = *pw;
     int res;
 
     /* Shortcut only for old-style types */
@@ -2233,7 +2233,7 @@ void
 _Py_ForgetReference(register PyObject *op)
 {
 #ifdef SLOW_UNREF_CHECK
-    register PyObject *p;
+    PyObject *p;
 #endif
     if (op->ob_refcnt < 0)
         Py_FatalError("UNREF negative refcnt");

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2230,7 +2230,7 @@ _Py_NewReference(PyObject *op)
 }
 
 void
-_Py_ForgetReference(register PyObject *op)
+_Py_ForgetReference(PyObject *op)
 {
 #ifdef SLOW_UNREF_CHECK
     PyObject *p;

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -70,7 +70,7 @@ NULL if the rich comparison returns an error.
 */
 
 static setentry *
-set_lookkey(PySetObject *so, PyObject *key, register long hash)
+set_lookkey(PySetObject *so, PyObject *key,long hash)
 {
     Py_ssize_t i;
     size_t perturb;
@@ -152,7 +152,7 @@ set_lookkey(PySetObject *so, PyObject *key, register long hash)
  * see if the comparison altered the table.
  */
 static setentry *
-set_lookkey_string(PySetObject *so, PyObject *key, register long hash)
+set_lookkey_string(PySetObject *so, PyObject *key,long hash)
 {
     Py_ssize_t i;
     size_t perturb;
@@ -206,7 +206,7 @@ Used by the public insert routine.
 Eats a reference to key.
 */
 static int
-set_insert_key(register PySetObject *so, PyObject *key, long hash)
+set_insert_key(PySetObject *so, PyObject *key, long hash)
 {
     setentry *entry;
 
@@ -242,7 +242,7 @@ Note that no refcounts are changed by this routine; if needed, the caller
 is responsible for incref'ing `key`.
 */
 static void
-set_insert_clean(register PySetObject *so, PyObject *key, long hash)
+set_insert_clean(PySetObject *so, PyObject *key, long hash)
 {
     size_t i;
     size_t perturb;
@@ -355,7 +355,7 @@ set_table_resize(PySetObject *so, Py_ssize_t minused)
 /* CAUTION: set_add_key/entry() must guarantee it won't resize the table */
 
 static int
-set_add_entry(register PySetObject *so, setentry *entry)
+set_add_entry(PySetObject *so, setentry *entry)
 {
     Py_ssize_t n_used;
     PyObject *key = entry->key;
@@ -374,7 +374,7 @@ set_add_entry(register PySetObject *so, setentry *entry)
 }
 
 static int
-set_add_key(register PySetObject *so, PyObject *key)
+set_add_key(PySetObject *so, PyObject *key)
 {
     long hash;
     Py_ssize_t n_used;

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -72,13 +72,13 @@ NULL if the rich comparison returns an error.
 static setentry *
 set_lookkey(PySetObject *so, PyObject *key, register long hash)
 {
-    register Py_ssize_t i;
-    register size_t perturb;
-    register setentry *freeslot;
-    register size_t mask = so->mask;
+    Py_ssize_t i;
+    size_t perturb;
+    setentry *freeslot;
+    size_t mask = so->mask;
     setentry *table = so->table;
-    register setentry *entry;
-    register int cmp;
+    setentry *entry;
+    int cmp;
     PyObject *startkey;
 
     i = hash & mask;
@@ -154,12 +154,12 @@ set_lookkey(PySetObject *so, PyObject *key, register long hash)
 static setentry *
 set_lookkey_string(PySetObject *so, PyObject *key, register long hash)
 {
-    register Py_ssize_t i;
-    register size_t perturb;
-    register setentry *freeslot;
-    register size_t mask = so->mask;
+    Py_ssize_t i;
+    size_t perturb;
+    setentry *freeslot;
+    size_t mask = so->mask;
     setentry *table = so->table;
-    register setentry *entry;
+    setentry *entry;
 
     /* Make sure this function doesn't have to handle non-string keys,
        including subclasses of str; e.g., one reason to subclass
@@ -208,7 +208,7 @@ Eats a reference to key.
 static int
 set_insert_key(register PySetObject *so, PyObject *key, long hash)
 {
-    register setentry *entry;
+    setentry *entry;
 
     assert(so->lookup != NULL);
     entry = so->lookup(so, key, hash);
@@ -244,11 +244,11 @@ is responsible for incref'ing `key`.
 static void
 set_insert_clean(register PySetObject *so, PyObject *key, long hash)
 {
-    register size_t i;
-    register size_t perturb;
-    register size_t mask = (size_t)so->mask;
+    size_t i;
+    size_t perturb;
+    size_t mask = (size_t)so->mask;
     setentry *table = so->table;
-    register setentry *entry;
+    setentry *entry;
 
     i = hash & mask;
     entry = &table[i];
@@ -357,7 +357,7 @@ set_table_resize(PySetObject *so, Py_ssize_t minused)
 static int
 set_add_entry(register PySetObject *so, setentry *entry)
 {
-    register Py_ssize_t n_used;
+    Py_ssize_t n_used;
     PyObject *key = entry->key;
     long hash = entry->hash;
 
@@ -376,8 +376,8 @@ set_add_entry(register PySetObject *so, setentry *entry)
 static int
 set_add_key(register PySetObject *so, PyObject *key)
 {
-    register long hash;
-    register Py_ssize_t n_used;
+    long hash;
+    Py_ssize_t n_used;
 
     if (!PyString_CheckExact(key) ||
         (hash = ((PyStringObject *) key)->ob_shash) == -1) {
@@ -402,7 +402,7 @@ set_add_key(register PySetObject *so, PyObject *key)
 
 static int
 set_discard_entry(PySetObject *so, setentry *oldentry)
-{       register setentry *entry;
+{       setentry *entry;
     PyObject *old_key;
 
     entry = (so->lookup)(so, oldentry->key, oldentry->hash);
@@ -421,8 +421,8 @@ set_discard_entry(PySetObject *so, setentry *oldentry)
 static int
 set_discard_key(PySetObject *so, PyObject *key)
 {
-    register long hash;
-    register setentry *entry;
+    long hash;
+    setentry *entry;
     PyObject *old_key;
 
     assert (PyAnySet_Check(so));
@@ -527,7 +527,7 @@ set_next(PySetObject *so, Py_ssize_t *pos_ptr, setentry **entry_ptr)
 {
     Py_ssize_t i;
     Py_ssize_t mask;
-    register setentry *table;
+    setentry *table;
 
     assert (PyAnySet_Check(so));
     i = *pos_ptr;
@@ -547,7 +547,7 @@ set_next(PySetObject *so, Py_ssize_t *pos_ptr, setentry **entry_ptr)
 static void
 set_dealloc(PySetObject *so)
 {
-    register setentry *entry;
+    setentry *entry;
     Py_ssize_t fill = so->fill;
     PyObject_GC_UnTrack(so);
     Py_TRASHCAN_SAFE_BEGIN(so)
@@ -647,8 +647,8 @@ set_merge(PySetObject *so, PyObject *otherset)
     PySetObject *other;
     PyObject *key;
     long hash;
-    register Py_ssize_t i;
-    register setentry *entry;
+    Py_ssize_t i;
+    setentry *entry;
 
     assert (PyAnySet_Check(so));
     assert (PyAnySet_Check(otherset));
@@ -716,8 +716,8 @@ set_contains_entry(PySetObject *so, setentry *entry)
 static PyObject *
 set_pop(PySetObject *so)
 {
-    register Py_ssize_t i = 0;
-    register setentry *entry;
+    Py_ssize_t i = 0;
+    setentry *entry;
     PyObject *key;
 
     assert (PyAnySet_Check(so));
@@ -841,8 +841,8 @@ static PyMethodDef setiter_methods[] = {
 static PyObject *setiter_iternext(setiterobject *si)
 {
     PyObject *key;
-    register Py_ssize_t i, mask;
-    register setentry *entry;
+    Py_ssize_t i, mask;
+    setentry *entry;
     PySetObject *so = si->si_set;
 
     if (so == NULL)
@@ -996,7 +996,7 @@ PyDoc_STRVAR(update_doc,
 static PyObject *
 make_new_set(PyTypeObject *type, PyObject *iterable)
 {
-    register PySetObject *so = NULL;
+    PySetObject *so = NULL;
 
     if (dummy == NULL) { /* Auto-initialize dummy */
         dummy = PyString_FromString("<dummy key>");

--- a/Objects/stringlib/split.h
+++ b/Objects/stringlib/split.h
@@ -348,8 +348,8 @@ stringlib_splitlines(PyObject* str_obj,
        and the appends only done when the prealloc buffer is full.
        That's too much work for little gain.*/
 
-    register Py_ssize_t i;
-    register Py_ssize_t j;
+    Py_ssize_t i;
+    Py_ssize_t j;
     PyObject *list = PyList_New(0);
     PyObject *sub;
 

--- a/Objects/stringobject.c
+++ b/Objects/stringobject.c
@@ -760,7 +760,7 @@ PyObject *PyString_DecodeEscape(const char *s,
 /* object api */
 
 static Py_ssize_t
-string_getsize(register PyObject *op)
+string_getsize(PyObject *op)
 {
     char *s;
     Py_ssize_t len;
@@ -770,7 +770,7 @@ string_getsize(register PyObject *op)
 }
 
 static /*const*/ char *
-string_getbuffer(register PyObject *op)
+string_getbuffer(PyObject *op)
 {
     char *s;
     Py_ssize_t len;
@@ -780,7 +780,7 @@ string_getbuffer(register PyObject *op)
 }
 
 Py_ssize_t
-PyString_Size(register PyObject *op)
+PyString_Size(PyObject *op)
 {
     if (!PyString_Check(op))
         return string_getsize(op);
@@ -788,7 +788,7 @@ PyString_Size(register PyObject *op)
 }
 
 /*const*/ char *
-PyString_AsString(register PyObject *op)
+PyString_AsString(PyObject *op)
 {
     if (!PyString_Check(op))
         return string_getbuffer(op);
@@ -796,7 +796,7 @@ PyString_AsString(register PyObject *op)
 }
 
 int
-PyString_AsStringAndSize(register PyObject *obj,
+PyString_AsStringAndSize(PyObject *obj,
                          char **s,
                          Py_ssize_t *len)
 {
@@ -1013,7 +1013,7 @@ string_length(PyStringObject *a)
 }
 
 static PyObject *
-string_concat(register PyStringObject *a, register PyObject *bb)
+string_concat(PyStringObject *a,PyObject *bb)
 {
     Py_ssize_t size;
     PyStringObject *op;
@@ -1072,7 +1072,7 @@ string_concat(register PyStringObject *a, register PyObject *bb)
 }
 
 static PyObject *
-string_repeat(register PyStringObject *a, register Py_ssize_t n)
+string_repeat(PyStringObject *a,Py_ssize_t n)
 {
     Py_ssize_t i;
     Py_ssize_t j;
@@ -1127,7 +1127,7 @@ string_repeat(register PyStringObject *a, register Py_ssize_t n)
 /* String slice a[i:j] consists of characters a[i] ... a[j-1] */
 
 static PyObject *
-string_slice(register PyStringObject *a, register Py_ssize_t i,
+string_slice(PyStringObject *a,Py_ssize_t i,
              Py_ssize_t j)
      /* j -- may be negative! */
 {
@@ -1167,7 +1167,7 @@ string_contains(PyObject *str_obj, PyObject *sub_obj)
 }
 
 static PyObject *
-string_item(PyStringObject *a, register Py_ssize_t i)
+string_item(PyStringObject *a,Py_ssize_t i)
 {
     char pchar;
     PyObject *v;
@@ -3846,7 +3846,7 @@ PyTypeObject PyString_Type = {
 };
 
 void
-PyString_Concat(register PyObject **pv, register PyObject *w)
+PyString_Concat(PyObject **pv,PyObject *w)
 {
     PyObject *v;
     if (*pv == NULL)
@@ -3860,7 +3860,7 @@ PyString_Concat(register PyObject **pv, register PyObject *w)
 }
 
 void
-PyString_ConcatAndDel(register PyObject **pv, register PyObject *w)
+PyString_ConcatAndDel(PyObject **pv,PyObject *w)
 {
     PyString_Concat(pv, w);
     Py_XDECREF(w);

--- a/Objects/stringobject.c
+++ b/Objects/stringobject.c
@@ -56,7 +56,7 @@ static PyObject *interned;
 PyObject *
 PyString_FromStringAndSize(const char *str, Py_ssize_t size)
 {
-    register PyStringObject *op;
+    PyStringObject *op;
     if (size < 0) {
         PyErr_SetString(PyExc_SystemError,
             "Negative size passed to PyString_FromStringAndSize");
@@ -114,8 +114,8 @@ PyString_FromStringAndSize(const char *str, Py_ssize_t size)
 PyObject *
 PyString_FromString(const char *str)
 {
-    register size_t size;
-    register PyStringObject *op;
+    size_t size;
+    PyStringObject *op;
 
     assert(str != NULL);
     size = strlen(str);
@@ -797,8 +797,8 @@ PyString_AsString(register PyObject *op)
 
 int
 PyString_AsStringAndSize(register PyObject *obj,
-                         register char **s,
-                         register Py_ssize_t *len)
+                         char **s,
+                         Py_ssize_t *len)
 {
     if (s == NULL) {
         PyErr_BadInternalCall();
@@ -925,7 +925,7 @@ string_print(PyStringObject *op, FILE *fp, int flags)
 PyObject *
 PyString_Repr(PyObject *obj, int smartquotes)
 {
-    register PyStringObject* op = (PyStringObject*) obj;
+    PyStringObject* op = (PyStringObject*) obj;
     size_t newsize;
     PyObject *v;
     if (Py_SIZE(op) > (PY_SSIZE_T_MAX - 2)/4) {
@@ -939,9 +939,9 @@ PyString_Repr(PyObject *obj, int smartquotes)
         return NULL;
     }
     else {
-        register Py_ssize_t i;
-        register char c;
-        register char *p;
+        Py_ssize_t i;
+        char c;
+        char *p;
         int quote;
 
         /* figure out which quote to use; single is preferred */
@@ -1015,8 +1015,8 @@ string_length(PyStringObject *a)
 static PyObject *
 string_concat(register PyStringObject *a, register PyObject *bb)
 {
-    register Py_ssize_t size;
-    register PyStringObject *op;
+    Py_ssize_t size;
+    PyStringObject *op;
     if (!PyString_Check(bb)) {
 #ifdef Py_USING_UNICODE
         if (PyUnicode_Check(bb))
@@ -1074,10 +1074,10 @@ string_concat(register PyStringObject *a, register PyObject *bb)
 static PyObject *
 string_repeat(register PyStringObject *a, register Py_ssize_t n)
 {
-    register Py_ssize_t i;
-    register Py_ssize_t j;
-    register Py_ssize_t size;
-    register PyStringObject *op;
+    Py_ssize_t i;
+    Py_ssize_t j;
+    Py_ssize_t size;
+    PyStringObject *op;
     size_t nbytes;
     if (n < 0)
         n = 0;
@@ -1128,7 +1128,7 @@ string_repeat(register PyStringObject *a, register Py_ssize_t n)
 
 static PyObject *
 string_slice(register PyStringObject *a, register Py_ssize_t i,
-             register Py_ssize_t j)
+             Py_ssize_t j)
      /* j -- may be negative! */
 {
     if (i < 0)
@@ -1262,9 +1262,9 @@ _PyString_Eq(PyObject *o1, PyObject *o2)
 static long
 string_hash(PyStringObject *a)
 {
-    register Py_ssize_t len;
-    register unsigned char *p;
-    register long x;
+    Py_ssize_t len;
+    unsigned char *p;
+    long x;
 
 #ifdef Py_DEBUG
     assert(_Py_HashSecret_Initialized);
@@ -2197,9 +2197,9 @@ the operation simply removes the characters in deletechars.");
 static PyObject *
 string_translate(PyStringObject *self, PyObject *args)
 {
-    register char *input, *output;
+    char *input, *output;
     const char *table;
-    register Py_ssize_t i, c, changed = 0;
+    Py_ssize_t i, c, changed = 0;
     PyObject *input_obj = (PyObject*)self;
     const char *output_start, *del_table=NULL;
     Py_ssize_t inlen, tablen, dellen = 0;
@@ -3309,9 +3309,9 @@ and there is at least one character in S, False otherwise.");
 static PyObject*
 string_isspace(PyStringObject *self)
 {
-    register const unsigned char *p
+    const unsigned char *p
         = (unsigned char *) PyString_AS_STRING(self);
-    register const unsigned char *e;
+    const unsigned char *e;
 
     /* Shortcut for single character strings */
     if (PyString_GET_SIZE(self) == 1 &&
@@ -3340,9 +3340,9 @@ and there is at least one character in S, False otherwise.");
 static PyObject*
 string_isalpha(PyStringObject *self)
 {
-    register const unsigned char *p
+    const unsigned char *p
         = (unsigned char *) PyString_AS_STRING(self);
-    register const unsigned char *e;
+    const unsigned char *e;
 
     /* Shortcut for single character strings */
     if (PyString_GET_SIZE(self) == 1 &&
@@ -3371,9 +3371,9 @@ and there is at least one character in S, False otherwise.");
 static PyObject*
 string_isalnum(PyStringObject *self)
 {
-    register const unsigned char *p
+    const unsigned char *p
         = (unsigned char *) PyString_AS_STRING(self);
-    register const unsigned char *e;
+    const unsigned char *e;
 
     /* Shortcut for single character strings */
     if (PyString_GET_SIZE(self) == 1 &&
@@ -3402,9 +3402,9 @@ and there is at least one character in S, False otherwise.");
 static PyObject*
 string_isdigit(PyStringObject *self)
 {
-    register const unsigned char *p
+    const unsigned char *p
         = (unsigned char *) PyString_AS_STRING(self);
-    register const unsigned char *e;
+    const unsigned char *e;
 
     /* Shortcut for single character strings */
     if (PyString_GET_SIZE(self) == 1 &&
@@ -3433,9 +3433,9 @@ at least one cased character in S, False otherwise.");
 static PyObject*
 string_islower(PyStringObject *self)
 {
-    register const unsigned char *p
+    const unsigned char *p
         = (unsigned char *) PyString_AS_STRING(self);
-    register const unsigned char *e;
+    const unsigned char *e;
     int cased;
 
     /* Shortcut for single character strings */
@@ -3467,9 +3467,9 @@ at least one cased character in S, False otherwise.");
 static PyObject*
 string_isupper(PyStringObject *self)
 {
-    register const unsigned char *p
+    const unsigned char *p
         = (unsigned char *) PyString_AS_STRING(self);
-    register const unsigned char *e;
+    const unsigned char *e;
     int cased;
 
     /* Shortcut for single character strings */
@@ -3503,9 +3503,9 @@ otherwise.");
 static PyObject*
 string_istitle(PyStringObject *self, PyObject *uncased)
 {
-    register const unsigned char *p
+    const unsigned char *p
         = (unsigned char *) PyString_AS_STRING(self);
-    register const unsigned char *e;
+    const unsigned char *e;
     int cased, previous_is_cased;
 
     /* Shortcut for single character strings */
@@ -3520,7 +3520,7 @@ string_istitle(PyStringObject *self, PyObject *uncased)
     cased = 0;
     previous_is_cased = 0;
     for (; p < e; p++) {
-        register const unsigned char ch = *p;
+        const unsigned char ch = *p;
 
         if (isupper(ch)) {
             if (previous_is_cased)
@@ -3848,7 +3848,7 @@ PyTypeObject PyString_Type = {
 void
 PyString_Concat(register PyObject **pv, register PyObject *w)
 {
-    register PyObject *v;
+    PyObject *v;
     if (*pv == NULL)
         return;
     if (w == NULL || !PyString_Check(*pv)) {
@@ -3884,8 +3884,8 @@ PyString_ConcatAndDel(register PyObject **pv, register PyObject *w)
 int
 _PyString_Resize(PyObject **pv, Py_ssize_t newsize)
 {
-    register PyObject *v;
-    register PyStringObject *sv;
+    PyObject *v;
+    PyStringObject *sv;
     v = *pv;
     if (!PyString_Check(v) || Py_REFCNT(v) != 1 || newsize < 0 ||
         PyString_CHECK_INTERNED(v)) {
@@ -4737,7 +4737,7 @@ PyString_Format(PyObject *format, PyObject *args)
 void
 PyString_InternInPlace(PyObject **p)
 {
-    register PyStringObject *s = (PyStringObject *)(*p);
+    PyStringObject *s = (PyStringObject *)(*p);
     PyObject *t;
     if (s == NULL || !PyString_Check(s))
         Py_FatalError("PyString_InternInPlace: strings only please!");

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -48,7 +48,7 @@ show_track(void)
 PyObject *
 PyTuple_New(register Py_ssize_t size)
 {
-    register PyTupleObject *op;
+    PyTupleObject *op;
     Py_ssize_t i;
     if (size < 0) {
         PyErr_BadInternalCall();
@@ -135,8 +135,8 @@ PyTuple_GetItem(register PyObject *op, register Py_ssize_t i)
 int
 PyTuple_SetItem(register PyObject *op, register Py_ssize_t i, PyObject *newitem)
 {
-    register PyObject *olditem;
-    register PyObject **p;
+    PyObject *olditem;
+    PyObject **p;
     if (!PyTuple_Check(op) || op->ob_refcnt != 1) {
         Py_XDECREF(newitem);
         PyErr_BadInternalCall();
@@ -212,8 +212,8 @@ PyTuple_Pack(Py_ssize_t n, ...)
 static void
 tupledealloc(register PyTupleObject *op)
 {
-    register Py_ssize_t i;
-    register Py_ssize_t len =  Py_SIZE(op);
+    Py_ssize_t i;
+    Py_ssize_t len =  Py_SIZE(op);
     PyObject_GC_UnTrack(op);
     Py_TRASHCAN_SAFE_BEGIN(op)
     if (len > 0) {
@@ -341,9 +341,9 @@ Done:
 static long
 tuplehash(PyTupleObject *v)
 {
-    register long x, y;
-    register Py_ssize_t len = Py_SIZE(v);
-    register PyObject **p;
+    long x, y;
+    Py_ssize_t len = Py_SIZE(v);
+    PyObject **p;
     long mult = 1000003L;
     x = 0x345678L;
     p = v->ob_item;
@@ -392,11 +392,11 @@ tupleitem(register PyTupleObject *a, register Py_ssize_t i)
 
 static PyObject *
 tupleslice(register PyTupleObject *a, register Py_ssize_t ilow,
-           register Py_ssize_t ihigh)
+           Py_ssize_t ihigh)
 {
-    register PyTupleObject *np;
+    PyTupleObject *np;
     PyObject **src, **dest;
-    register Py_ssize_t i;
+    Py_ssize_t i;
     Py_ssize_t len;
     if (ilow < 0)
         ilow = 0;
@@ -435,8 +435,8 @@ PyTuple_GetSlice(PyObject *op, Py_ssize_t i, Py_ssize_t j)
 static PyObject *
 tupleconcat(register PyTupleObject *a, register PyObject *bb)
 {
-    register Py_ssize_t size;
-    register Py_ssize_t i;
+    Py_ssize_t size;
+    Py_ssize_t i;
     PyObject **src, **dest;
     PyTupleObject *np;
     if (!PyTuple_Check(bb)) {
@@ -836,8 +836,8 @@ PyTypeObject PyTuple_Type = {
 int
 _PyTuple_Resize(PyObject **pv, Py_ssize_t newsize)
 {
-    register PyTupleObject *v;
-    register PyTupleObject *sv;
+    PyTupleObject *v;
+    PyTupleObject *sv;
     Py_ssize_t i;
     Py_ssize_t oldsize;
 

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -46,7 +46,7 @@ show_track(void)
 
 
 PyObject *
-PyTuple_New(register Py_ssize_t size)
+PyTuple_New(Py_ssize_t size)
 {
     PyTupleObject *op;
     Py_ssize_t i;
@@ -108,7 +108,7 @@ PyTuple_New(register Py_ssize_t size)
 }
 
 Py_ssize_t
-PyTuple_Size(register PyObject *op)
+PyTuple_Size(PyObject *op)
 {
     if (!PyTuple_Check(op)) {
         PyErr_BadInternalCall();
@@ -119,7 +119,7 @@ PyTuple_Size(register PyObject *op)
 }
 
 PyObject *
-PyTuple_GetItem(register PyObject *op, register Py_ssize_t i)
+PyTuple_GetItem(PyObject *op,Py_ssize_t i)
 {
     if (!PyTuple_Check(op)) {
         PyErr_BadInternalCall();
@@ -133,7 +133,7 @@ PyTuple_GetItem(register PyObject *op, register Py_ssize_t i)
 }
 
 int
-PyTuple_SetItem(register PyObject *op, register Py_ssize_t i, PyObject *newitem)
+PyTuple_SetItem(PyObject *op,Py_ssize_t i, PyObject *newitem)
 {
     PyObject *olditem;
     PyObject **p;
@@ -210,7 +210,7 @@ PyTuple_Pack(Py_ssize_t n, ...)
 /* Methods */
 
 static void
-tupledealloc(register PyTupleObject *op)
+tupledealloc(PyTupleObject *op)
 {
     Py_ssize_t i;
     Py_ssize_t len =  Py_SIZE(op);
@@ -380,7 +380,7 @@ tuplecontains(PyTupleObject *a, PyObject *el)
 }
 
 static PyObject *
-tupleitem(register PyTupleObject *a, register Py_ssize_t i)
+tupleitem(PyTupleObject *a,Py_ssize_t i)
 {
     if (i < 0 || i >= Py_SIZE(a)) {
         PyErr_SetString(PyExc_IndexError, "tuple index out of range");
@@ -391,7 +391,7 @@ tupleitem(register PyTupleObject *a, register Py_ssize_t i)
 }
 
 static PyObject *
-tupleslice(register PyTupleObject *a, register Py_ssize_t ilow,
+tupleslice(PyTupleObject *a,Py_ssize_t ilow,
            Py_ssize_t ihigh)
 {
     PyTupleObject *np;
@@ -433,7 +433,7 @@ PyTuple_GetSlice(PyObject *op, Py_ssize_t i, Py_ssize_t j)
 }
 
 static PyObject *
-tupleconcat(register PyTupleObject *a, register PyObject *bb)
+tupleconcat(PyTupleObject *a,PyObject *bb)
 {
     Py_ssize_t size;
     Py_ssize_t i;

--- a/Objects/unicodectype.c
+++ b/Objects/unicodectype.c
@@ -54,7 +54,7 @@ gettyperecord(Py_UNICODE code)
 /* Returns the titlecase Unicode characters corresponding to ch or just
    ch if no titlecase mapping is known. */
 
-Py_UNICODE _PyUnicode_ToTitlecase(register Py_UNICODE ch)
+Py_UNICODE _PyUnicode_ToTitlecase(Py_UNICODE ch)
 {
     const _PyUnicode_TypeRecord *ctype = gettyperecord(ch);
     int delta = ctype->title;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -257,7 +257,7 @@ Py_LOCAL_INLINE(int) unicode_member(Py_UNICODE chr, Py_UNICODE* set, Py_ssize_t 
 /* --- Unicode Object ----------------------------------------------------- */
 
 static
-int unicode_resize(register PyUnicodeObject *unicode,
+int unicode_resize(PyUnicodeObject *unicode,
                    Py_ssize_t length)
 {
     void *oldstr;
@@ -385,7 +385,7 @@ PyUnicodeObject *_PyUnicode_New(Py_ssize_t length)
 }
 
 static
-void unicode_dealloc(register PyUnicodeObject *unicode)
+void unicode_dealloc(PyUnicodeObject *unicode)
 {
     if (PyUnicode_CheckExact(unicode) &&
         numfree < PyUnicode_MAXFREELIST) {
@@ -588,7 +588,7 @@ PyObject *PyUnicode_FromString(const char *u)
 /* Here sizeof(wchar_t) is 4 but Py_UNICODE_SIZE == 2, so we need
    to convert from UTF32 to UTF16. */
 
-PyObject *PyUnicode_FromWideChar(register const wchar_t *w,
+PyObject *PyUnicode_FromWideChar(const wchar_t *w,
                                  Py_ssize_t size)
 {
     PyUnicodeObject *unicode;
@@ -633,7 +633,7 @@ PyObject *PyUnicode_FromWideChar(register const wchar_t *w,
 
 #else
 
-PyObject *PyUnicode_FromWideChar(register const wchar_t *w,
+PyObject *PyUnicode_FromWideChar(const wchar_t *w,
                                  Py_ssize_t size)
 {
     PyUnicodeObject *unicode;
@@ -1143,7 +1143,7 @@ PyObject *PyUnicode_FromOrdinal(int ordinal)
     return PyUnicode_FromUnicode(s, 1);
 }
 
-PyObject *PyUnicode_FromObject(register PyObject *obj)
+PyObject *PyUnicode_FromObject(PyObject *obj)
 {
     /* XXX Perhaps we should make this API an alias of
        PyObject_Unicode() instead ?! */
@@ -1160,7 +1160,7 @@ PyObject *PyUnicode_FromObject(register PyObject *obj)
     return PyUnicode_FromEncodedObject(obj, NULL, "strict");
 }
 
-PyObject *PyUnicode_FromEncodedObject(register PyObject *obj,
+PyObject *PyUnicode_FromEncodedObject(PyObject *obj,
                                       const char *encoding,
                                       const char *errors)
 {

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -316,7 +316,7 @@ int unicode_resize(register PyUnicodeObject *unicode,
 static
 PyUnicodeObject *_PyUnicode_New(Py_ssize_t length)
 {
-    register PyUnicodeObject *unicode;
+    PyUnicodeObject *unicode;
 
     /* Optimization for empty strings */
     if (length == 0 && unicode_empty != NULL) {
@@ -413,7 +413,7 @@ void unicode_dealloc(register PyUnicodeObject *unicode)
 static
 int _PyUnicode_Resize(PyUnicodeObject **unicode, Py_ssize_t length)
 {
-    register PyUnicodeObject *v;
+    PyUnicodeObject *v;
 
     /* Argument checks */
     if (unicode == NULL) {
@@ -592,7 +592,7 @@ PyObject *PyUnicode_FromWideChar(register const wchar_t *w,
                                  Py_ssize_t size)
 {
     PyUnicodeObject *unicode;
-    register Py_ssize_t i;
+    Py_ssize_t i;
     Py_ssize_t alloc;
     const wchar_t *orig_w;
 
@@ -615,7 +615,7 @@ PyObject *PyUnicode_FromWideChar(register const wchar_t *w,
 
     /* Copy the wchar_t data into the new object */
     {
-        register Py_UNICODE *u;
+        Py_UNICODE *u;
         u = PyUnicode_AS_UNICODE(unicode);
         for (i = size; i > 0; i--) {
             if (*w > 0xFFFF) {
@@ -652,8 +652,8 @@ PyObject *PyUnicode_FromWideChar(register const wchar_t *w,
     memcpy(unicode->str, w, size * sizeof(wchar_t));
 #else
     {
-        register Py_UNICODE *u;
-        register Py_ssize_t i;
+        Py_UNICODE *u;
+        Py_ssize_t i;
         u = PyUnicode_AS_UNICODE(unicode);
         for (i = size; i > 0; i--)
             *u++ = *w++;
@@ -1103,8 +1103,8 @@ Py_ssize_t PyUnicode_AsWideChar(PyUnicodeObject *unicode,
     memcpy(w, unicode->str, size * sizeof(wchar_t));
 #else
     {
-        register Py_UNICODE *u;
-        register Py_ssize_t i;
+        Py_UNICODE *u;
+        Py_ssize_t i;
         u = PyUnicode_AS_UNICODE(unicode);
         for (i = size; i > 0; i--)
             *w++ = *u++;
@@ -3848,7 +3848,7 @@ PyObject *PyUnicode_DecodeASCII(const char *s,
     p = PyUnicode_AS_UNICODE(v);
     e = s + size;
     while (s < e) {
-        register unsigned char c = (unsigned char)*s;
+        unsigned char c = (unsigned char)*s;
         if (c < 128) {
             *p++ = c;
             ++s;
@@ -5238,7 +5238,7 @@ int PyUnicode_EncodeDecimal(Py_UNICODE *s,
     p = s;
     end = s + length;
     while (p < end) {
-        register Py_UNICODE ch = *p;
+        Py_UNICODE ch = *p;
         int decimal;
         PyObject *repunicode;
         Py_ssize_t repsize;
@@ -5523,7 +5523,7 @@ int fixupper(PyUnicodeObject *self)
     int status = 0;
 
     while (len-- > 0) {
-        register Py_UNICODE ch;
+        Py_UNICODE ch;
 
         ch = Py_UNICODE_TOUPPER(*s);
         if (ch != *s) {
@@ -5544,7 +5544,7 @@ int fixlower(PyUnicodeObject *self)
     int status = 0;
 
     while (len-- > 0) {
-        register Py_UNICODE ch;
+        Py_UNICODE ch;
 
         ch = Py_UNICODE_TOLOWER(*s);
         if (ch != *s) {
@@ -5605,8 +5605,8 @@ int fixcapitalize(PyUnicodeObject *self)
 static
 int fixtitle(PyUnicodeObject *self)
 {
-    register Py_UNICODE *p = PyUnicode_AS_UNICODE(self);
-    register Py_UNICODE *e;
+    Py_UNICODE *p = PyUnicode_AS_UNICODE(self);
+    Py_UNICODE *e;
     int previous_is_cased;
 
     /* Shortcut for single character strings */
@@ -5623,7 +5623,7 @@ int fixtitle(PyUnicodeObject *self)
     e = p + PyUnicode_GET_SIZE(self);
     previous_is_cased = 0;
     for (; p < e; p++) {
-        register const Py_UNICODE ch = *p;
+        const Py_UNICODE ch = *p;
 
         if (previous_is_cased)
             *p = Py_UNICODE_TOLOWER(ch);
@@ -6188,7 +6188,7 @@ unicode_compare(PyUnicodeObject *str1, PyUnicodeObject *str2)
 static int
 unicode_compare(PyUnicodeObject *str1, PyUnicodeObject *str2)
 {
-    register Py_ssize_t len1, len2;
+    Py_ssize_t len1, len2;
 
     Py_UNICODE *s1 = str1->str;
     Py_UNICODE *s2 = str2->str;
@@ -6642,9 +6642,9 @@ unicode_hash(PyUnicodeObject *self)
        strings and Unicode objects behave in the same way as
        dictionary keys. */
 
-    register Py_ssize_t len;
-    register Py_UNICODE *p;
-    register long x;
+    Py_ssize_t len;
+    Py_UNICODE *p;
+    long x;
 
 #ifdef Py_DEBUG
     assert(_Py_HashSecret_Initialized);
@@ -6715,8 +6715,8 @@ at least one cased character in S, False otherwise.");
 static PyObject*
 unicode_islower(PyUnicodeObject *self)
 {
-    register const Py_UNICODE *p = PyUnicode_AS_UNICODE(self);
-    register const Py_UNICODE *e;
+    const Py_UNICODE *p = PyUnicode_AS_UNICODE(self);
+    const Py_UNICODE *e;
     int cased;
 
     /* Shortcut for single character strings */
@@ -6730,7 +6730,7 @@ unicode_islower(PyUnicodeObject *self)
     e = p + PyUnicode_GET_SIZE(self);
     cased = 0;
     for (; p < e; p++) {
-        register const Py_UNICODE ch = *p;
+        const Py_UNICODE ch = *p;
 
         if (Py_UNICODE_ISUPPER(ch) || Py_UNICODE_ISTITLE(ch))
             return PyBool_FromLong(0);
@@ -6749,8 +6749,8 @@ at least one cased character in S, False otherwise.");
 static PyObject*
 unicode_isupper(PyUnicodeObject *self)
 {
-    register const Py_UNICODE *p = PyUnicode_AS_UNICODE(self);
-    register const Py_UNICODE *e;
+    const Py_UNICODE *p = PyUnicode_AS_UNICODE(self);
+    const Py_UNICODE *e;
     int cased;
 
     /* Shortcut for single character strings */
@@ -6764,7 +6764,7 @@ unicode_isupper(PyUnicodeObject *self)
     e = p + PyUnicode_GET_SIZE(self);
     cased = 0;
     for (; p < e; p++) {
-        register const Py_UNICODE ch = *p;
+        const Py_UNICODE ch = *p;
 
         if (Py_UNICODE_ISLOWER(ch) || Py_UNICODE_ISTITLE(ch))
             return PyBool_FromLong(0);
@@ -6785,8 +6785,8 @@ Return False otherwise.");
 static PyObject*
 unicode_istitle(PyUnicodeObject *self)
 {
-    register const Py_UNICODE *p = PyUnicode_AS_UNICODE(self);
-    register const Py_UNICODE *e;
+    const Py_UNICODE *p = PyUnicode_AS_UNICODE(self);
+    const Py_UNICODE *e;
     int cased, previous_is_cased;
 
     /* Shortcut for single character strings */
@@ -6802,7 +6802,7 @@ unicode_istitle(PyUnicodeObject *self)
     cased = 0;
     previous_is_cased = 0;
     for (; p < e; p++) {
-        register const Py_UNICODE ch = *p;
+        const Py_UNICODE ch = *p;
 
         if (Py_UNICODE_ISUPPER(ch) || Py_UNICODE_ISTITLE(ch)) {
             if (previous_is_cased)
@@ -6831,8 +6831,8 @@ and there is at least one character in S, False otherwise.");
 static PyObject*
 unicode_isspace(PyUnicodeObject *self)
 {
-    register const Py_UNICODE *p = PyUnicode_AS_UNICODE(self);
-    register const Py_UNICODE *e;
+    const Py_UNICODE *p = PyUnicode_AS_UNICODE(self);
+    const Py_UNICODE *e;
 
     /* Shortcut for single character strings */
     if (PyUnicode_GET_SIZE(self) == 1 &&
@@ -6860,8 +6860,8 @@ and there is at least one character in S, False otherwise.");
 static PyObject*
 unicode_isalpha(PyUnicodeObject *self)
 {
-    register const Py_UNICODE *p = PyUnicode_AS_UNICODE(self);
-    register const Py_UNICODE *e;
+    const Py_UNICODE *p = PyUnicode_AS_UNICODE(self);
+    const Py_UNICODE *e;
 
     /* Shortcut for single character strings */
     if (PyUnicode_GET_SIZE(self) == 1 &&
@@ -6889,8 +6889,8 @@ and there is at least one character in S, False otherwise.");
 static PyObject*
 unicode_isalnum(PyUnicodeObject *self)
 {
-    register const Py_UNICODE *p = PyUnicode_AS_UNICODE(self);
-    register const Py_UNICODE *e;
+    const Py_UNICODE *p = PyUnicode_AS_UNICODE(self);
+    const Py_UNICODE *e;
 
     /* Shortcut for single character strings */
     if (PyUnicode_GET_SIZE(self) == 1 &&
@@ -6918,8 +6918,8 @@ False otherwise.");
 static PyObject*
 unicode_isdecimal(PyUnicodeObject *self)
 {
-    register const Py_UNICODE *p = PyUnicode_AS_UNICODE(self);
-    register const Py_UNICODE *e;
+    const Py_UNICODE *p = PyUnicode_AS_UNICODE(self);
+    const Py_UNICODE *e;
 
     /* Shortcut for single character strings */
     if (PyUnicode_GET_SIZE(self) == 1 &&
@@ -6947,8 +6947,8 @@ and there is at least one character in S, False otherwise.");
 static PyObject*
 unicode_isdigit(PyUnicodeObject *self)
 {
-    register const Py_UNICODE *p = PyUnicode_AS_UNICODE(self);
-    register const Py_UNICODE *e;
+    const Py_UNICODE *p = PyUnicode_AS_UNICODE(self);
+    const Py_UNICODE *e;
 
     /* Shortcut for single character strings */
     if (PyUnicode_GET_SIZE(self) == 1 &&
@@ -6976,8 +6976,8 @@ False otherwise.");
 static PyObject*
 unicode_isnumeric(PyUnicodeObject *self)
 {
-    register const Py_UNICODE *p = PyUnicode_AS_UNICODE(self);
-    register const Py_UNICODE *e;
+    const Py_UNICODE *p = PyUnicode_AS_UNICODE(self);
+    const Py_UNICODE *e;
 
     /* Shortcut for single character strings */
     if (PyUnicode_GET_SIZE(self) == 1 &&
@@ -8128,7 +8128,7 @@ getnextarg(PyObject *args, Py_ssize_t arglen, Py_ssize_t *p_argidx)
 static Py_ssize_t
 strtounicode(Py_UNICODE *buffer, const char *charbuffer)
 {
-    register Py_ssize_t i;
+    Py_ssize_t i;
     Py_ssize_t len = strlen(charbuffer);
     for (i = len - 1; i >= 0; i--)
         buffer[i] = (Py_UNICODE) charbuffer[i];

--- a/Objects/unicodetype_db.h
+++ b/Objects/unicodetype_db.h
@@ -3271,7 +3271,7 @@ double _PyUnicode_ToNumeric(Py_UNICODE ch)
 /* Returns 1 for Unicode characters having the bidirectional
  * type 'WS', 'B' or 'S' or the category 'Zs', 0 otherwise.
  */
-int _PyUnicode_IsWhitespace(register const Py_UNICODE ch)
+int _PyUnicode_IsWhitespace(const Py_UNICODE ch)
 {
 #ifdef WANT_WCTYPE_FUNCTIONS
     return iswspace(ch);
@@ -3317,7 +3317,7 @@ int _PyUnicode_IsWhitespace(register const Py_UNICODE ch)
  * property 'BK', 'CR', 'LF' or 'NL' or having bidirectional
  * type 'B', 0 otherwise.
  */
-int _PyUnicode_IsLinebreak(register const Py_UNICODE ch)
+int _PyUnicode_IsLinebreak(const Py_UNICODE ch)
 {
     switch (ch) {
     case 0x000A:

--- a/Parser/grammar1.c
+++ b/Parser/grammar1.c
@@ -11,7 +11,7 @@
 dfa *
 PyGrammar_FindDFA(grammar *g, register int type)
 {
-    register dfa *d;
+    dfa *d;
 #if 1
     /* Massive speed-up */
     d = &g->g_dfa[type - NT_OFFSET];
@@ -19,7 +19,7 @@ PyGrammar_FindDFA(grammar *g, register int type)
     return d;
 #else
     /* Old, slow version */
-    register int i;
+    int i;
 
     for (i = g->g_ndfas, d = g->g_dfa; --i >= 0; d++) {
         if (d->d_type == type)

--- a/Parser/grammar1.c
+++ b/Parser/grammar1.c
@@ -9,7 +9,7 @@
 /* Return the DFA for the given type */
 
 dfa *
-PyGrammar_FindDFA(grammar *g, register int type)
+PyGrammar_FindDFA(grammar *g,int type)
 {
     dfa *d;
 #if 1

--- a/Parser/node.c
+++ b/Parser/node.c
@@ -76,7 +76,7 @@ fancy_roundup(int n)
 
 
 int
-PyNode_AddChild(register node *n1, int type, char *str, int lineno, int col_offset)
+PyNode_AddChild(node *n1, int type, char *str, int lineno, int col_offset)
 {
     const int nch = n1->n_nchildren;
     int current_capacity;

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -37,7 +37,7 @@ s_reset(stack *s)
 static int
 s_push(register stack *s, dfa *d, node *parent)
 {
-    register stackentry *top;
+    stackentry *top;
     if (s->s_top == s->s_base) {
         fprintf(stderr, "s_push: parser stack overflow\n");
         return E_NOMEM;
@@ -120,7 +120,7 @@ static int
 push(register stack *s, int type, dfa *d, int newstate, int lineno, int col_offset)
 {
     int err;
-    register node *n;
+    node *n;
     n = s->s_top->s_parent;
     assert(!s_empty(s));
     err = PyNode_AddChild(n, type, (char *)NULL, lineno, col_offset);
@@ -137,12 +137,12 @@ static int
 classify(parser_state *ps, int type, char *str)
 {
     grammar *g = ps->p_grammar;
-    register int n = g->g_ll.ll_nlabels;
+    int n = g->g_ll.ll_nlabels;
 
     if (type == NAME) {
-        register char *s = str;
-        register label *l = g->g_ll.ll_label;
-        register int i;
+        char *s = str;
+        label *l = g->g_ll.ll_label;
+        int i;
         for (i = n; i > 0; i--, l++) {
             if (l->lb_type != NAME || l->lb_str == NULL ||
                 l->lb_str[0] != s[0] ||
@@ -160,8 +160,8 @@ classify(parser_state *ps, int type, char *str)
     }
 
     {
-        register label *l = g->g_ll.ll_label;
-        register int i;
+        label *l = g->g_ll.ll_label;
+        int i;
         for (i = n; i > 0; i--, l++) {
             if (l->lb_type == type && l->lb_str == NULL) {
                 D(printf("It's a token we know\n"));
@@ -220,7 +220,7 @@ int
 PyParser_AddToken(register parser_state *ps, register int type, char *str,
                   int lineno, int col_offset, int *expected_ret)
 {
-    register int ilabel;
+    int ilabel;
     int err;
 
     D(printf("Token %s/'%s' ... ", _PyParser_TokenNames[type], str));
@@ -233,15 +233,15 @@ PyParser_AddToken(register parser_state *ps, register int type, char *str,
     /* Loop until the token is shifted or an error occurred */
     for (;;) {
         /* Fetch the current dfa and state */
-        register dfa *d = ps->p_stack.s_top->s_dfa;
-        register state *s = &d->d_state[ps->p_stack.s_top->s_state];
+        dfa *d = ps->p_stack.s_top->s_dfa;
+        state *s = &d->d_state[ps->p_stack.s_top->s_state];
 
         D(printf(" DFA '%s', state %d:",
             d->d_name, ps->p_stack.s_top->s_state));
 
         /* Check accelerator */
         if (s->s_lower <= ilabel && ilabel < s->s_upper) {
-            register int x = s->s_accel[ilabel - s->s_lower];
+            int x = s->s_accel[ilabel - s->s_lower];
             if (x != -1) {
                 if (x & (1<<7)) {
                     /* Push non-terminal */

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -35,7 +35,7 @@ s_reset(stack *s)
 #define s_empty(s) ((s)->s_top == &(s)->s_base[MAXSTACK])
 
 static int
-s_push(register stack *s, dfa *d, node *parent)
+s_push(stack *s, dfa *d, node *parent)
 {
     stackentry *top;
     if (s->s_top == s->s_base) {
@@ -52,7 +52,7 @@ s_push(register stack *s, dfa *d, node *parent)
 #ifdef Py_DEBUG
 
 static void
-s_pop(register stack *s)
+s_pop(stack *s)
 {
     if (s_empty(s))
         Py_FatalError("s_pop: parser stack underflow -- FATAL");
@@ -105,7 +105,7 @@ PyParser_Delete(parser_state *ps)
 /* PARSER STACK OPERATIONS */
 
 static int
-shift(register stack *s, int type, char *str, int newstate, int lineno, int col_offset)
+shift(stack *s, int type, char *str, int newstate, int lineno, int col_offset)
 {
     int err;
     assert(!s_empty(s));
@@ -117,7 +117,7 @@ shift(register stack *s, int type, char *str, int newstate, int lineno, int col_
 }
 
 static int
-push(register stack *s, int type, dfa *d, int newstate, int lineno, int col_offset)
+push(stack *s, int type, dfa *d, int newstate, int lineno, int col_offset)
 {
     int err;
     node *n;
@@ -217,7 +217,7 @@ future_hack(parser_state *ps)
 #endif /* future keyword */
 
 int
-PyParser_AddToken(register parser_state *ps, register int type, char *str,
+PyParser_AddToken(parser_state *ps,int type, char *str,
                   int lineno, int col_offset, int *expected_ret)
 {
     int ilabel;

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1215,7 +1215,7 @@ indenterror(struct tok_state *tok)
 static int
 tok_get(register struct tok_state *tok, char **p_start, char **p_end)
 {
-    register int c;
+    int c;
     int blankline;
 
     *p_start = *p_end = NULL;
@@ -1225,8 +1225,8 @@ tok_get(register struct tok_state *tok, char **p_start, char **p_end)
 
     /* Get indentation level */
     if (tok->atbol) {
-        register int col = 0;
-        register int altcol = 0;
+        int col = 0;
+        int altcol = 0;
         tok->atbol = 0;
         for (;;) {
             c = tok_nextc(tok);

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -854,7 +854,7 @@ error_clear:
 /* Get next char, updating state; error code goes into tok->done */
 
 static int
-tok_nextc(register struct tok_state *tok)
+tok_nextc(struct tok_state *tok)
 {
     for (;;) {
         if (tok->cur != tok->inp) {
@@ -1027,7 +1027,7 @@ tok_nextc(register struct tok_state *tok)
 /* Back-up one character */
 
 static void
-tok_backup(register struct tok_state *tok, register int c)
+tok_backup(struct tok_state *tok,int c)
 {
     if (c != EOF) {
         if (--tok->cur < tok->buf)
@@ -1213,7 +1213,7 @@ indenterror(struct tok_state *tok)
 /* Get next token, after space stripping etc. */
 
 static int
-tok_get(register struct tok_state *tok, char **p_start, char **p_end)
+tok_get(struct tok_state *tok, char **p_start, char **p_end)
 {
     int c;
     int blankline;

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -245,7 +245,7 @@ builtin_filter(PyObject *self, PyObject *args)
 {
     PyObject *func, *seq, *result, *it, *arg;
     Py_ssize_t len;   /* guess for result list size */
-    register Py_ssize_t j;
+    Py_ssize_t j;
 
     if (!PyArg_UnpackTuple(args, "filter", 2, 2, &func, &seq))
         return NULL;
@@ -947,7 +947,7 @@ builtin_map(PyObject *self, PyObject *args)
     PyObject *func, *result;
     sequence *seqs = NULL, *sqp;
     Py_ssize_t n, len;
-    register int i, j;
+    int i, j;
 
     n = PyTuple_Size(args);
     if (n < 2) {
@@ -2960,7 +2960,7 @@ static PyObject *
 filterunicode(PyObject *func, PyObject *strobj)
 {
     PyObject *result;
-    register Py_ssize_t i, j;
+    Py_ssize_t i, j;
     Py_ssize_t len = PyUnicode_GetSize(strobj);
     Py_ssize_t outlen = len;
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -38,7 +38,7 @@ typedef unsigned long long uint64;
 static void
 ppc_getcounter(uint64 *v)
 {
-    register unsigned long tbu, tb, tbu2;
+    unsigned long tbu, tb, tbu2;
 
   loop:
     asm volatile ("mftbu %0" : "=r" (tbu) );
@@ -785,19 +785,19 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
 #ifdef DXPAIRS
     int lastopcode = 0;
 #endif
-    register PyObject **stack_pointer;  /* Next free slot in value stack */
-    register unsigned char *next_instr;
-    register int opcode;        /* Current opcode */
-    register int oparg;         /* Current opcode argument, if any */
-    register enum why_code why; /* Reason for block stack unwind */
-    register int err;           /* Error status -- nonzero if error */
-    register PyObject *x;       /* Result object -- NULL if error */
-    register PyObject *v;       /* Temporary objects popped off stack */
-    register PyObject *w;
-    register PyObject *u;
-    register PyObject *t;
-    register PyObject *stream = NULL;    /* for PRINT opcodes */
-    register PyObject **fastlocals, **freevars;
+    PyObject **stack_pointer;  /* Next free slot in value stack */
+    unsigned char *next_instr;
+    int opcode;        /* Current opcode */
+    int oparg;         /* Current opcode argument, if any */
+    enum why_code why; /* Reason for block stack unwind */
+    int err;           /* Error status -- nonzero if error */
+    PyObject *x;       /* Result object -- NULL if error */
+    PyObject *v;       /* Temporary objects popped off stack */
+    PyObject *w;
+    PyObject *u;
+    PyObject *t;
+    PyObject *stream = NULL;    /* for PRINT opcodes */
+    PyObject **fastlocals, **freevars;
     PyObject *retval = NULL;            /* Return value */
     PyThreadState *tstate = PyThreadState_GET();
     PyCodeObject *co;
@@ -1467,7 +1467,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
             v = TOP();
             if (PyInt_CheckExact(v) && PyInt_CheckExact(w)) {
                 /* INLINE: int + int */
-                register long a, b, i;
+                long a, b, i;
                 a = PyInt_AS_LONG(v);
                 b = PyInt_AS_LONG(w);
                 /* cast to avoid undefined behaviour
@@ -1501,7 +1501,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
             v = TOP();
             if (PyInt_CheckExact(v) && PyInt_CheckExact(w)) {
                 /* INLINE: int - int */
-                register long a, b, i;
+                long a, b, i;
                 a = PyInt_AS_LONG(v);
                 b = PyInt_AS_LONG(w);
                 /* cast to avoid undefined behaviour
@@ -1715,7 +1715,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
             v = TOP();
             if (PyInt_CheckExact(v) && PyInt_CheckExact(w)) {
                 /* INLINE: int + int */
-                register long a, b, i;
+                long a, b, i;
                 a = PyInt_AS_LONG(v);
                 b = PyInt_AS_LONG(w);
                 i = a + b;
@@ -1747,7 +1747,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
             v = TOP();
             if (PyInt_CheckExact(v) && PyInt_CheckExact(w)) {
                 /* INLINE: int - int */
-                register long a, b, i;
+                long a, b, i;
                 a = PyInt_AS_LONG(v);
                 b = PyInt_AS_LONG(w);
                 i = a - b;
@@ -2557,8 +2557,8 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
             v = TOP();
             if (PyInt_CheckExact(w) && PyInt_CheckExact(v)) {
                 /* INLINE: cmp(int, int) */
-                register long a, b;
-                register int res;
+                long a, b;
+                int res;
                 a = PyInt_AS_LONG(v);
                 b = PyInt_AS_LONG(w);
                 switch (oparg) {
@@ -3353,9 +3353,9 @@ PyEval_EvalCodeEx(PyCodeObject *co, PyObject *globals, PyObject *locals,
            PyObject **args, int argcount, PyObject **kws, int kwcount,
            PyObject **defs, int defcount, PyObject *closure)
 {
-    register PyFrameObject *f;
-    register PyObject *retval = NULL;
-    register PyObject **fastlocals, **freevars;
+    PyFrameObject *f;
+    PyObject *retval = NULL;
+    PyObject **fastlocals, **freevars;
     PyThreadState *tstate = PyThreadState_GET();
     PyObject *x, *u;
 
@@ -4019,7 +4019,7 @@ static int
 call_trace(Py_tracefunc func, PyObject *obj, PyFrameObject *frame,
            int what, PyObject *arg)
 {
-    register PyThreadState *tstate = frame->f_tstate;
+    PyThreadState *tstate = frame->f_tstate;
     int result;
     if (tstate->tracing)
         return 0;

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4806,7 +4806,7 @@ assign_slice(PyObject *u, PyObject *v, PyObject *w, PyObject *x)
                          "BaseException is not allowed in 3.x"
 
 static PyObject *
-cmp_outcome(int op, register PyObject *v, register PyObject *w)
+cmp_outcome(int op,PyObject *v,PyObject *w)
 {
     int res = 0;
     switch (op) {

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -51,7 +51,7 @@ int PyCodec_Register(PyObject *search_function)
 static
 PyObject *normalizestring(const char *string)
 {
-    register size_t i;
+    size_t i;
     size_t len = strlen(string);
     char *p;
     PyObject *v;
@@ -66,7 +66,7 @@ PyObject *normalizestring(const char *string)
         return NULL;
     p = PyString_AS_STRING(v);
     for (i = 0; i < len; i++) {
-        register char ch = string[i];
+        char ch = string[i];
         if (ch == ' ')
             ch = '-';
         else

--- a/Python/dynload_aix.c
+++ b/Python/dynload_aix.c
@@ -35,11 +35,11 @@ const struct filedescr _PyImport_DynLoadFiletab[] = {
 static int
 aix_getoldmodules(void **modlistptr)
 {
-    register ModulePtr       modptr, prevmodptr;
-    register struct ld_info  *ldiptr;
-    register char            *ldibuf;
-    register int             errflag, bufsize = 1024;
-    register unsigned int    offset;
+    ModulePtr       modptr, prevmodptr;
+    struct ld_info  *ldiptr;
+    char            *ldibuf;
+    int             errflag, bufsize = 1024;
+    unsigned int    offset;
     char *progname = Py_GetProgramName();
 
     /*
@@ -109,7 +109,7 @@ aix_loaderror(const char *pathname)
 {
 
     char *message[1024], errbuf[1024];
-    register int i,j;
+    int i,j;
 
     struct errtab {
         int errNo;

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -507,7 +507,7 @@ r_string(char *s, Py_ssize_t n, RFILE *p)
 static int
 r_short(RFILE *p)
 {
-    register short x;
+    short x;
     x = r_byte(p);
     x |= r_byte(p) << 8;
     /* Sign-extension, in case short greater than 16 bits */
@@ -518,8 +518,8 @@ r_short(RFILE *p)
 static long
 r_long(RFILE *p)
 {
-    register long x;
-    register FILE *fp = p->fp;
+    long x;
+    FILE *fp = p->fp;
     if (fp) {
         x = getc(fp);
         x |= (long)getc(fp) << 8;

--- a/Python/mystrtoul.c
+++ b/Python/mystrtoul.c
@@ -94,9 +94,9 @@ static int digitlimit[] = {
 unsigned long
 PyOS_strtoul(register char *str, char **ptr, int base)
 {
-    register unsigned long result = 0; /* return value of the function */
-    register int c;             /* current input character */
-    register int ovlimit;       /* required digits to overflow */
+    unsigned long result = 0; /* return value of the function */
+    int c;             /* current input character */
+    int ovlimit;       /* required digits to overflow */
 
     /* skip leading white space */
     while (*str && isspace(Py_CHARMASK(*str)))
@@ -207,7 +207,7 @@ PyOS_strtoul(register char *str, char **ptr, int base)
         if (ovlimit > 0) /* no overflow check required */
             result = result * base + c;
         else { /* requires overflow check */
-            register unsigned long temp_result;
+            unsigned long temp_result;
 
             if (ovlimit < 0) /* guaranteed overflow */
                 goto overflowed;

--- a/Python/mystrtoul.c
+++ b/Python/mystrtoul.c
@@ -92,7 +92,7 @@ static int digitlimit[] = {
 **              exceptions - we don't check for them.
 */
 unsigned long
-PyOS_strtoul(register char *str, char **ptr, int base)
+PyOS_strtoul(char *str, char **ptr, int base)
 {
     unsigned long result = 0; /* return value of the function */
     int c;             /* current input character */

--- a/Python/strtod.c
+++ b/Python/strtod.c
@@ -67,8 +67,8 @@ double strtod(char *str, char **ptr)
     int sign, scale, dotseen;
     int esign, expt;
     char *save;
-    register char *sp, *dp;
-    register int c;
+    char *sp, *dp;
+    int c;
     char *buforg, *buflim;
     char buffer[64];                    /* 45-digit significant + */
                     /* 13-digit exponent */

--- a/Tools/unicode/makeunicodedata.py
+++ b/Tools/unicode/makeunicodedata.py
@@ -500,7 +500,7 @@ def makeunicodetype(unicode, trace):
     print >>fp, "/* Returns 1 for Unicode characters having the bidirectional"
     print >>fp, " * type 'WS', 'B' or 'S' or the category 'Zs', 0 otherwise."
     print >>fp, " */"
-    print >>fp, 'int _PyUnicode_IsWhitespace(register const Py_UNICODE ch)'
+    print >>fp, 'int _PyUnicode_IsWhitespace(const Py_UNICODE ch)'
     print >>fp, '{'
     print >>fp, '#ifdef WANT_WCTYPE_FUNCTIONS'
     print >>fp, '    return iswspace(ch);'
@@ -533,7 +533,7 @@ def makeunicodetype(unicode, trace):
     print >>fp, " * property 'BK', 'CR', 'LF' or 'NL' or having bidirectional"
     print >>fp, " * type 'B', 0 otherwise."
     print >>fp, " */"
-    print >>fp, 'int _PyUnicode_IsLinebreak(register const Py_UNICODE ch)'
+    print >>fp, 'int _PyUnicode_IsLinebreak(const Py_UNICODE ch)'
     print >>fp, '{'
     print >>fp, '    switch (ch) {'
     haswide = False


### PR DESCRIPTION
Removing register specifier from cpython .c .h and .py as deprecated in c++17 standard and it causes comp warnings for gcc7 IBs